### PR TITLE
Fix .vocab files with no prefix not compiling

### DIFF
--- a/.changeset/small-geese-promise.md
+++ b/.changeset/small-geese-promise.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+Fix .vocab files with no prefix not compiling

--- a/fixtures/simple/src/.vocab/fr.translations.json
+++ b/fixtures/simple/src/.vocab/fr.translations.json
@@ -1,0 +1,8 @@
+{
+  "hello": {
+    "message": "Bonjour"
+  },
+  "world": {
+    "message": "monde"
+  }
+}

--- a/fixtures/simple/src/.vocab/translations.json
+++ b/fixtures/simple/src/.vocab/translations.json
@@ -1,0 +1,8 @@
+{
+  "hello": {
+    "message": "Hello"
+  },
+  "world": {
+    "message": "world"
+  }
+}

--- a/fixtures/simple/src/client.tsx
+++ b/fixtures/simple/src/client.tsx
@@ -2,17 +2,19 @@ import { VocabProvider, useTranslations } from '@vocab/react';
 import React, { ReactNode, useState } from 'react';
 import { render } from 'react-dom';
 
-import translations from './client.vocab';
+import commonTranslations from './.vocab';
+import clientTranslations from './client.vocab';
 
 function Content() {
-  const { t } = useTranslations(translations);
-  const message = `${t('hello')} ${t('world')}`;
+  const common = useTranslations(commonTranslations);
+  const client = useTranslations(clientTranslations);
+  const message = `${common.t('hello')} ${common.t('world')}`;
 
   return (
     <>
       <div id="message">{message}</div>
       <div id="publish-date">
-        {t('vocabPublishDate', { publishDate: 1605847714000 })}
+        {client.t('vocabPublishDate', { publishDate: 1605847714000 })}
       </div>
     </>
   );

--- a/fixtures/simple/src/client.vocab/fr.translations.json
+++ b/fixtures/simple/src/client.vocab/fr.translations.json
@@ -1,10 +1,4 @@
 {
-  "hello": {
-    "message": "Bonjour"
-  },
-  "world": {
-    "message": "monde"
-  },
   "vocabPublishDate": {
     "message": "Vocab a été publié le {publishDate, date, medium}"
   }

--- a/fixtures/simple/src/client.vocab/translations.json
+++ b/fixtures/simple/src/client.vocab/translations.json
@@ -1,10 +1,4 @@
 {
-  "hello": {
-    "message": "Hello"
-  },
-  "world": {
-    "message": "world"
-  },
   "vocabPublishDate": {
     "message": "Vocab was published on {publishDate, date, small}"
   }

--- a/packages/core/src/utils.ts
+++ b/packages/core/src/utils.ts
@@ -14,6 +14,8 @@ export const devTranslationFileName = 'translations.json';
 
 export type Fallback = 'none' | 'valid' | 'all';
 
+const globAnyPathWithOptionalPrefix = '**/?(*)';
+
 export function isDevLanguageFile(filePath: string) {
   return (
     filePath.endsWith(`/${devTranslationFileName}`) ||
@@ -39,7 +41,7 @@ export function getTranslationFolderGlob({
 }: {
   translationsDirectorySuffix?: string;
 }) {
-  const result = `**/*${translationsDirectorySuffix}`;
+  const result = `${globAnyPathWithOptionalPrefix}${translationsDirectorySuffix}`;
 
   trace('getTranslationFolderGlob', result);
 
@@ -51,7 +53,7 @@ export function getDevTranslationFileGlob({
 }: {
   translationsDirectorySuffix?: string;
 }) {
-  const result = `**/*${translationsDirectorySuffix}/${devTranslationFileName}`;
+  const result = `${globAnyPathWithOptionalPrefix}${translationsDirectorySuffix}/${devTranslationFileName}`;
 
   trace('getDevTranslationFileGlob', result);
 


### PR DESCRIPTION
Some implementations of glob patterns seem to assume `*` character stands for 1-many, but we we wanted 0-many.
Wrapping in an optional group `?()` we ensure the glob works across either implemenation.