### PR TITLE
Update changesets action sha

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@bfeb9e0
+        uses: changesets/action@b3300fad33b6ab794313da28d27424c0e2f78991
         with:
           publish: yarn release
         env:


### PR DESCRIPTION
Update changesets action SHA to comply with upcoming Github change to deprecate short SHA support.

See [Security hardening for GitHub Actions > Using Third Party Actions](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#using-third-party-actions) for more details.