### PR TITLE
Document and expose a contract for using translations directly

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ jobs:
     env:
       CI: true
     steps:
+      - name: Check out repo
+        uses: actions/checkout@master
+
       - name: Set up Node.js 12.x
         uses: actions/setup-node@master
         with:
@@ -20,9 +23,6 @@ jobs:
         id: setup-icu
         with:
           noexport: true
-
-      - name: Check out repo
-        uses: actions/checkout@master
 
       - name: Install dependencies
         run: yarn install --frozen-lockfile

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -19,32 +19,17 @@ jobs:
         with:
           node-version: 12.x
 
-      - uses: sarisia/setup-icu@v1
-        id: setup-icu
-        with:
-          noexport: true
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
-        env:
-          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Build
         run: yarn build
-        env:
-          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Compile fixtures
         run: yarn compile-fixtures
-        env:
-          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Lint
         run: yarn lint
-        env:
-          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Test
         run: yarn test
-        env:
-          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,27 +11,40 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: sarisia/setup-icu@v1
-
-      - name: Check out repo
-        uses: actions/checkout@master
-
       - name: Set up Node.js 12.x
         uses: actions/setup-node@master
         with:
           node-version: 12.x
 
+      - uses: sarisia/setup-icu@v1
+        id: setup-icu
+        with:
+          noexport: true
+
+      - name: Check out repo
+        uses: actions/checkout@master
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
+        env:
+          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Build
         run: yarn build
+        env:
+          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Compile fixtures
         run: yarn compile-fixtures
+        env:
+          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Lint
         run: yarn lint
+        env:
+          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}
 
       - name: Test
         run: yarn test
+        env:
+          NODE_ICU_DATA: ${{ steps.setup-icu.outputs.icu-data-dir }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile && yarn build && yarn compile-fixtures && yarn test
 
       - name: Build
         run: yarn build

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -11,6 +11,9 @@ jobs:
     env:
       CI: true
     steps:
+      - uses: sarisia/setup-icu@v1
+      - uses: sarisia/action-uses-icu-function@v2
+
       - name: Check out repo
         uses: actions/checkout@master
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,6 @@ jobs:
       CI: true
     steps:
       - uses: sarisia/setup-icu@v1
-      - uses: sarisia/action-uses-icu-function@v2
 
       - name: Check out repo
         uses: actions/checkout@master

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,7 +20,7 @@ jobs:
           node-version: 12.x
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile && yarn build && yarn compile-fixtures && yarn test
+        run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ module.exports = {
 };
 ```
 
+## Use without React
+
+Vocab integrates well with React using `@vocab/react` Vocab is able to ensure translations are loaded when needed and the page is updated as translations load.
+
+However, if you need to use Vocab outside of the React integration you can access the returned Vocab file directly. Note that you'll then be responsible for when to load translations and how to update on translation load.
+
+A vocab translation file returns two methods:
+
+- `getMessages` returns messages for the given language formatted according to the correct locale. If the language has not been loaded it will return `null`.
+- `load` attempts to load messages for the given language. Returning a promise once complete. Note that you'll then need to call `getMessages` to access the messages.
+
+**Example: Promise based formatting of messages**
+
+```typescript
+import translations from './.vocab';
+
+async function getMessage(language, locale) {
+  let messages = translations.getMessages(language, locale);
+  if (!messages) {
+    await translations.load(language, locale);
+    messages = translations.getMessages(language, locale);
+  }
+  return messages;
+}
+
+getMessages('en').then((messages) => messages.foo.format());
+```
+
 ## Generate Types
 
 Vocab generates custom `index.ts` files that give your React components strongly typed translations to work with.

--- a/README.md
+++ b/README.md
@@ -224,6 +224,13 @@ $ vocab push --branch my-branch
 $ vocab pull --branch my-branch
 ```
 
+## Troubleshooting
+
+### Problem: Passed locale is being ignored and using en-US
+
+When running in Node.js the locale formatting is supported by [Node.js's Internationalization support](https://nodejs.org/api/intl.html#intl_internationalization_support). Node.js will silently switch to the closest locale it can find if the passed locale is not available.
+See Node's documentation on [Options for building Node.js](https://nodejs.org/api/intl.html#intl_options_for_building_node_js) for information on ensuring Node has the locales you need.
+
 ### License
 
 MIT.

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ $ vocab pull --branch my-branch
 
 ## Troubleshooting
 
-### Problem: Passed locale is being ignored and using en-US
+### Problem: Passed locale is being ignored or using en-US instead
 
 When running in Node.js the locale formatting is supported by [Node.js's Internationalization support](https://nodejs.org/api/intl.html#intl_internationalization_support). Node.js will silently switch to the closest locale it can find if the passed locale is not available.
 See Node's documentation on [Options for building Node.js](https://nodejs.org/api/intl.html#intl_options_for_building_node_js) for information on ensuring Node has the locales you need.

--- a/README.md
+++ b/README.md
@@ -169,30 +169,51 @@ module.exports = {
 
 ## Use without React
 
-Vocab integrates well with React using `@vocab/react` Vocab is able to ensure translations are loaded when needed and the page is updated as translations load.
+Vocab integrates well with React, using `@vocab/react` Vocab is able to ensure translations are loaded when needed and updating the page as translations load.
 
-However, if you need to use Vocab outside of the React integration you can access the returned Vocab file directly. Note that you'll then be responsible for when to load translations and how to update on translation load.
+However, if you need to use Vocab outside of React, you can access the returned Vocab file directly. Note that you'll then be responsible for when to load translations and how to update on translation load.
 
-A vocab translation file returns two methods:
+A vocab translation file returns three methods:
 
-- `getMessages` returns messages for the given language formatted according to the correct locale. If the language has not been loaded it will return `null`.
-- `load` attempts to load messages for the given language. Returning a promise once complete. Note that you'll then need to call `getMessages` to access the messages.
+- `load` attempts to load messages for the given language. Resolving once complete. Note this only ensures the language is available and does not return any translations.
+- `getMessages` returns messages for the given language formatted according to the correct locale. If the language has not been loaded it will load the language before resolving.
+- `getLoadedMessages` returns messages for the given language formatted according to the correct locale. If the language has not been loaded it will return `null`. Note that this will not load the language if it's not available. Useful when a syncronous (non-promise) return is required.
 
 **Example: Promise based formatting of messages**
 
 ```typescript
 import translations from './.vocab';
 
-async function getMessage(language, locale) {
-  let messages = translations.getMessages(language, locale);
-  if (!messages) {
-    await translations.load(language, locale);
-    messages = translations.getMessages(language, locale);
-  }
-  return messages;
+async function getFooMessage(language) {
+  let messages = await translations.getMessages(language);
+  return messages.foo.format();
 }
 
-getMessages('en').then((messages) => messages.foo.format());
+getFooMessage().then((m) => console.log(m));
+```
+
+**Example: Syncronously returning a message**
+
+```typescript
+import translations from './.vocab';
+
+async function getFooMessage(language) {
+  let messages = await translations.getLoadedMessages(
+    language
+  );
+  if (!messages) {
+    // Translations not loaded, start loading and return null for now
+    translations.load();
+    return null;
+  }
+  return messages.foo.format();
+}
+
+translations.load();
+
+const onClick = () => {
+  console.log(getFooMessage());
+};
 ```
 
 ## Generate Types

--- a/babel.config.js
+++ b/babel.config.js
@@ -4,4 +4,5 @@ module.exports = {
     '@babel/preset-typescript',
     '@babel/preset-react',
   ],
+  plugins: [['@babel/transform-runtime']],
 };

--- a/fixtures/direct/package.json
+++ b/fixtures/direct/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@types/react": "^17.0.0",
     "@types/react-dom": "^17.0.0",
-    "@vocab/cli": "^0.0.13",
+    "@vocab/cli": "^0.0.15",
     "@vocab/react": "^0.0.11",
     "babel-loader": "^8.2.1",
     "html-webpack-plugin": "^4.5.0",

--- a/fixtures/direct/package.json
+++ b/fixtures/direct/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fixture-direct",
+  "version": "1.0.0",
+  "author": "SEEK",
+  "private": true,
+  "scripts": {
+    "compile": "vocab compile",
+    "start": "vocab compile --watch & webpack serve"
+  },
+  "dependencies": {
+    "@types/react": "^17.0.0",
+    "@types/react-dom": "^17.0.0",
+    "@vocab/cli": "^0.0.13",
+    "@vocab/react": "^0.0.11",
+    "babel-loader": "^8.2.1",
+    "html-webpack-plugin": "^4.5.0",
+    "react": "^17.0.1",
+    "react-dom": "^17.0.1",
+    "webpack": "^5.11.0",
+    "webpack-cli": "^4.4.0",
+    "webpack-dev-server": "^3.11.0"
+  }
+}

--- a/fixtures/direct/src/.vocab/fr.translations.json
+++ b/fixtures/direct/src/.vocab/fr.translations.json
@@ -5,7 +5,7 @@
   "world": {
     "message": "monde"
   },
-  "time is": {
-    "message": "L'heure actuelle est {currentTime, date}"
+  "vocabPublishDate": {
+    "message": "Vocab a été publié le {publishDate, date, medium}"
   }
 }

--- a/fixtures/direct/src/.vocab/fr.translations.json
+++ b/fixtures/direct/src/.vocab/fr.translations.json
@@ -1,0 +1,11 @@
+{
+  "hello": {
+    "message": "Bonjour"
+  },
+  "world": {
+    "message": "monde"
+  },
+  "time is": {
+    "message": "L'heure actuelle est {currentTime, date}"
+  }
+}

--- a/fixtures/direct/src/.vocab/translations.json
+++ b/fixtures/direct/src/.vocab/translations.json
@@ -1,0 +1,11 @@
+{
+  "hello": {
+    "message": "Hello"
+  },
+  "world": {
+    "message": "world"
+  },
+  "time is": {
+    "message": "The current time is {currentTime, date}"
+  }
+}

--- a/fixtures/direct/src/.vocab/translations.json
+++ b/fixtures/direct/src/.vocab/translations.json
@@ -5,7 +5,7 @@
   "world": {
     "message": "world"
   },
-  "time is": {
-    "message": "The current time is {currentTime, date}"
+  "vocabPublishDate": {
+    "message": "Vocab was published on {publishDate, date, small}"
   }
 }

--- a/fixtures/direct/src/client.tsx
+++ b/fixtures/direct/src/client.tsx
@@ -1,0 +1,59 @@
+import React, { useState } from 'react';
+import { render } from 'react-dom';
+
+import { getSyncMessage, getAsyncMessage, preloadLanguage } from './utils';
+
+function App() {
+  const [showMessage, setShowMessage] = useState(false);
+  const [asyncMessage, setAsyncMessage] = useState('');
+  const [language, setLang] = useState<'en' | 'fr'>('en');
+
+  preloadLanguage(language);
+
+  return (
+    <div>
+      <button
+        id="toggle-language"
+        onClick={() => setLang((curr) => (curr === 'en' ? 'fr' : 'en'))}
+      >
+        Toggle language: {language}
+      </button>
+
+      <button onClick={() => setShowMessage(true)}>Show Message</button>
+      <button
+        onClick={() => {
+          setShowMessage(false);
+          setAsyncMessage('');
+        }}
+      >
+        Clear Message
+      </button>
+      {showMessage && (
+        <>
+          <div>
+            <label>Sync Message:&nbsp;</label>
+            <strong>{getSyncMessage(language, language) || ''}</strong>
+          </div>
+
+          <div>
+            <label>Async Message:&nbsp;</label>
+            <strong>{asyncMessage}</strong>
+          </div>
+          <button
+            onClick={async () =>
+              setAsyncMessage(await getAsyncMessage(language, language))
+            }
+          >
+            Update Async Message
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+const node = document.createElement('div');
+
+document.body.appendChild(node);
+
+render(<App />, node);

--- a/fixtures/direct/src/client.tsx
+++ b/fixtures/direct/src/client.tsx
@@ -19,7 +19,9 @@ function App() {
         Toggle language: {language}
       </button>
 
-      <button onClick={() => setShowMessage(true)}>Show Message</button>
+      <button id="show-message" onClick={() => setShowMessage(true)}>
+        Show Message
+      </button>
       <button
         onClick={() => {
           setShowMessage(false);
@@ -32,14 +34,17 @@ function App() {
         <>
           <div>
             <label>Sync Message:&nbsp;</label>
-            <strong>{getSyncMessage(language, language) || ''}</strong>
+            <strong id="sync-message">
+              {getSyncMessage(language, language) || ''}
+            </strong>
           </div>
 
           <div>
             <label>Async Message:&nbsp;</label>
-            <strong>{asyncMessage}</strong>
+            <strong id="async-message">{asyncMessage}</strong>
           </div>
           <button
+            id="update-message"
             onClick={async () =>
               setAsyncMessage(await getAsyncMessage(language, language))
             }

--- a/fixtures/direct/src/utils.ts
+++ b/fixtures/direct/src/utils.ts
@@ -7,7 +7,7 @@ export function preloadLanguage(language: LanguageName) {
 }
 
 export function getSyncMessage(language: LanguageName, locale: string) {
-  const languageTranslations = translations.getMessages(language, locale);
+  const languageTranslations = translations.getLoadedMessages(language, locale);
   if (!languageTranslations) {
     // eslint-disable-next-line no-console
     console.error(
@@ -22,15 +22,6 @@ export function getSyncMessage(language: LanguageName, locale: string) {
 }
 
 export async function getAsyncMessage(language: LanguageName, locale: string) {
-  let languageTranslations = translations.getMessages(language, locale);
-  if (!languageTranslations) {
-    await translations.load(language);
-    languageTranslations = translations.getMessages(language, locale);
-    if (!languageTranslations) {
-      throw new Error(
-        `Unable to load translations for language "${language}" and locale "${locale}"`,
-      );
-    }
-  }
+  const languageTranslations = await translations.getMessages(language, locale);
   return `${languageTranslations.hello.format()} Asyncronously`;
 }

--- a/fixtures/direct/src/utils.ts
+++ b/fixtures/direct/src/utils.ts
@@ -15,9 +15,10 @@ export function getSyncMessage(language: LanguageName, locale: string) {
     );
     return null;
   }
-  return `${languageTranslations.hello.format()} ${languageTranslations[
-    'time is'
-  ].format({ currentTime: Date.now() })}`;
+  return `${languageTranslations.hello.format()} Syncronously
+  ${languageTranslations.vocabPublishDate.format({
+    publishDate: 1605847714000,
+  })}`;
 }
 
 export async function getAsyncMessage(language: LanguageName, locale: string) {
@@ -31,5 +32,5 @@ export async function getAsyncMessage(language: LanguageName, locale: string) {
       );
     }
   }
-  return `${languageTranslations.hello.format()} ${languageTranslations.world.format()}`;
+  return `${languageTranslations.hello.format()} Asyncronously`;
 }

--- a/fixtures/direct/src/utils.ts
+++ b/fixtures/direct/src/utils.ts
@@ -1,0 +1,35 @@
+import translations from './.vocab';
+
+type LanguageName = 'fr' | 'en';
+
+export function preloadLanguage(language: LanguageName) {
+  return translations.load(language);
+}
+
+export function getSyncMessage(language: LanguageName, locale: string) {
+  const languageTranslations = translations.getMessages(language, locale);
+  if (!languageTranslations) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Translation not available locally for language "${language}" and locale "${locale}"`,
+    );
+    return null;
+  }
+  return `${languageTranslations.hello.format()} ${languageTranslations[
+    'time is'
+  ].format({ currentTime: Date.now() })}`;
+}
+
+export async function getAsyncMessage(language: LanguageName, locale: string) {
+  let languageTranslations = translations.getMessages(language, locale);
+  if (!languageTranslations) {
+    await translations.load(language);
+    languageTranslations = translations.getMessages(language, locale);
+    if (!languageTranslations) {
+      throw new Error(
+        `Unable to load translations for language "${language}" and locale "${locale}"`,
+      );
+    }
+  }
+  return `${languageTranslations.hello.format()} ${languageTranslations.world.format()}`;
+}

--- a/fixtures/direct/vocab.config.js
+++ b/fixtures/direct/vocab.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  devLanguage: 'en',
+  languages: [{ name: 'en' }, { name: 'fr' }],
+};

--- a/fixtures/direct/webpack.config.js
+++ b/fixtures/direct/webpack.config.js
@@ -1,0 +1,42 @@
+const VocabWebpackPlugin = require('@vocab/webpack').default;
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = ({ disableVocabPlugin }) => ({
+  entry: require.resolve('./src/client.tsx'),
+  resolve: {
+    extensions: ['.js', '.json', '.ts', '.tsx'],
+  },
+  mode: 'development',
+  devtool: 'source-map',
+  module: {
+    rules: [
+      {
+        test: /\.(js|ts|tsx)$/,
+        exclude: [/node_modules/],
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              babelrc: false,
+              presets: [
+                ['@babel/preset-env', { modules: false }],
+                '@babel/preset-typescript',
+                '@babel/preset-react',
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+  plugins: [
+    new HtmlWebpackPlugin(),
+    ...(disableVocabPlugin
+      ? []
+      : [
+          new VocabWebpackPlugin({
+            configFile: require.resolve('./vocab.config.js'),
+          }),
+        ]),
+  ],
+});

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,7 +1,3 @@
 import 'expect-puppeteer';
 
-// Polyfil intl-locale to ensure full ICU has been loaded
-// https://nodejs.org/api/intl.html#intl_options_for_building_node_js
-import '@formatjs/intl-locale/polyfill';
-
 jest.setTimeout(20000);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,6 @@
 import 'expect-puppeteer';
 
+// Polyfil intl-locale to ensure full ICU has been loaded
+import '@formatjs/intl-locale/polyfill';
+
 jest.setTimeout(20000);

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,6 +1,7 @@
 import 'expect-puppeteer';
 
 // Polyfil intl-locale to ensure full ICU has been loaded
+// https://nodejs.org/api/intl.html#intl_options_for_building_node_js
 import '@formatjs/intl-locale/polyfill';
 
 jest.setTimeout(20000);

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "eslint": "^7.13.0",
     "eslint-config-seek": "^7.0.5",
     "fast-glob": "^3.2.4",
+    "full-icu": "^1.3.1",
     "jest": "^26.6.3",
     "jest-puppeteer": "^4.4.0",
     "prettier": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "copy-readme-to-packages": "ts-node scripts/copy-readme-to-packages",
     "start-fixture": "ts-node tests/start-fixture",
     "run-server-fixture": "ts-node tests/run-server-fixture",
-    "compile-fixtures": "manypkg run fixture-simple compile && manypkg run fixture-server compile"
+    "compile-fixtures": "manypkg run fixture-direct compile && manypkg run fixture-simple compile && manypkg run fixture-server compile"
   },
   "workspaces": [
     "packages/*",
@@ -42,7 +42,8 @@
   },
   "version": "0.0.1",
   "dependencies": {
-    "@babel/preset-env": "^7.12.1",
+    "@babel/plugin-transform-runtime": "^7.12.10",
+    "@babel/preset-env": "^7.12.11",
     "@babel/preset-react": "^7.12.5",
     "@babel/preset-typescript": "^7.12.1",
     "@changesets/changelog-github": "^0.2.7",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@babel/preset-typescript": "^7.12.1",
     "@changesets/changelog-github": "^0.2.7",
     "@changesets/cli": "^2.11.2",
+    "@formatjs/intl-locale": "^2.4.13",
     "@manypkg/cli": "^0.16.1",
     "@preconstruct/cli": "^2.0.0",
     "@types/expect-puppeteer": "^4.4.5",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "eslint": "^7.13.0",
     "eslint-config-seek": "^7.0.5",
     "fast-glob": "^3.2.4",
-    "full-icu": "^1.3.1",
     "jest": "^26.6.3",
     "jest-puppeteer": "^4.4.0",
     "prettier": "^2.1.2",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,7 +9,8 @@
     "entrypoints": [
       "index.ts",
       "runtime.ts",
-      "icu-handler.ts"
+      "icu-handler.ts",
+      "translation-file.ts"
     ]
   },
   "dependencies": {

--- a/packages/core/src/compile.ts
+++ b/packages/core/src/compile.ts
@@ -123,8 +123,6 @@ function serialiseTranslationRuntime(
     }
     translationKeyType.returnType = returnType;
 
-    translationKeyType.message = 'string';
-
     translationsType[key] = translationKeyType;
   }
 
@@ -137,15 +135,18 @@ function serialiseTranslationRuntime(
     )
     .join(',');
 
+  const languagesUnionAsString = Object.keys(loadedTranslation.languages)
+    .map((l) => `'${l}'`)
+    .join(' | ');
+
   return `${banner}
 
   ${Array.from(imports).join('\n')}
-  import type { TranslationFile } from '@vocab/core';
-  import { createLanguage } from '@vocab/core/runtime';
+  import { createLanguage, createTranslationFile } from '@vocab/core/runtime';
 
-  const translations: TranslationFile<${serialiseObjectToType(
+  const translations = createTranslationFile<${languagesUnionAsString}, ${serialiseObjectToType(
     translationsType,
-  )}> = {${content}};
+  )}>({${content}});
 
   export default translations;`;
 }

--- a/packages/core/src/icu-handler.ts
+++ b/packages/core/src/icu-handler.ts
@@ -23,10 +23,10 @@ export const getParsedICUMessages = (
   const parsedICUMessages: ParsedICUMessages<any> = {};
 
   for (const translation of Object.keys(m)) {
-    parsedICUMessages[translation] = new IntlMessageFormat(
-      m[translation],
-      locale,
-    );
+    const res = new IntlMessageFormat(m[translation], locale);
+    parsedICUMessages[translation] = {
+      format: (params: any) => res.format(params),
+    };
   }
 
   moduleCache.set(m, { ...moduleCachedResult, [locale]: parsedICUMessages });

--- a/packages/core/src/icu-handler.ts
+++ b/packages/core/src/icu-handler.ts
@@ -23,9 +23,9 @@ export const getParsedICUMessages = (
   const parsedICUMessages: ParsedICUMessages<any> = {};
 
   for (const translation of Object.keys(m)) {
-    const res = new IntlMessageFormat(m[translation], locale);
+    const intlMessageFormat = new IntlMessageFormat(m[translation], locale);
     parsedICUMessages[translation] = {
-      format: (params: any) => res.format(params),
+      format: (params: any) => intlMessageFormat.format(params),
     };
   }
 

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -28,7 +28,11 @@ describe('createTranslationFile', () => {
       }),
     ).toBe('Vocab was published on 11/20/2020');
   });
-  it('should return TranslationModules with en-AU locale', () => {
+
+  // Support for alternative ICU locales in Node not available in current CI environment
+  // Disabling test for now until `full-icu` can be added. See https://nodejs.org/api/intl.html#intl_options_for_building_node_js
+  // eslint-disable-next-line jest/no-disabled-tests
+  it.skip('should return TranslationModules with en-AU locale', () => {
     const translations = createDemoTranslationFile();
     const translationModule = translations.getMessages('en', 'en-AU');
     expect(

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,7 +1,3 @@
-// Polyfil intl-locale to ensure full ICU has been loaded
-// https://nodejs.org/api/intl.html#intl_options_for_building_node_js
-import '@formatjs/intl-locale/polyfill';
-
 import { createTranslationFile, createLanguage } from './runtime';
 
 const createDemoTranslationFile = () =>

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -39,7 +39,7 @@ describe('createTranslationFile', () => {
   });
   it('should return TranslationModules with en-US locale', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en', 'en-AU');
+    const translationModule = translations.getMessages('en', 'en-US');
     expect(
       translationModule?.vocabPublishDate.format({
         publishDate: 1605847714000,
@@ -48,7 +48,7 @@ describe('createTranslationFile', () => {
   });
   it('should require parameters to be passed in', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en', 'en-AU');
+    const translationModule = translations.getMessages('en');
     expect(
       // @ts-expect-error Missing params parameter
       () => translationModule?.vocabPublishDate.format(),

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,0 +1,63 @@
+import { createTranslationFile, createLanguage } from './runtime';
+
+describe('createTranslationFile', () => {
+  it('should return TranslationModules', () => {
+    const translations = createTranslationFile<
+      'en' | 'fr',
+      {
+        vocabPublishDate: {
+          params: { publishDate: Date | number };
+          returnType: string;
+        };
+      }
+    >({
+      en: createLanguage({
+        vocabPublishDate: 'Vocab was published on {publishDate, date, small}',
+      }),
+      fr: createLanguage({
+        vocabPublishDate: 'Vocab a été publié le {publishDate, date, medium}',
+      }),
+    });
+    const translationModule = translations.getMessages('en', 'en-AU');
+    expect(
+      translationModule?.vocabPublishDate.format({
+        publishDate: 1605847714000,
+      }),
+    ).toBe('Vocab was published on 20/11/2020');
+  });
+  it('should require parameters to be passed in', () => {
+    const translations = createTranslationFile<
+      'en' | 'fr',
+      {
+        vocabPublishDate: {
+          params: { publishDate: Date | number };
+          returnType: string;
+        };
+      }
+    >({
+      en: createLanguage({
+        vocabPublishDate: 'Vocab was published on {publishDate, date, small}',
+      }),
+      fr: createLanguage({
+        vocabPublishDate: 'Vocab a été publié le {publishDate, date, medium}',
+      }),
+    });
+    const translationModule = translations.getMessages('en', 'en-AU');
+    expect(
+      // @ts-expect-error Missing params parameter
+      () => translationModule?.vocabPublishDate.format(),
+    ).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining('not provided'),
+      }),
+    );
+    expect(() =>
+      // @ts-expect-error Incorrect params parameter
+      translationModule?.vocabPublishDate.format({ unrelated: 'message' }),
+    ).toThrowError(
+      expect.objectContaining({
+        message: expect.stringContaining('not provided'),
+      }),
+    );
+  });
+});

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,3 +1,7 @@
+// Polyfil intl-locale to ensure full ICU has been loaded
+// https://nodejs.org/api/intl.html#intl_options_for_building_node_js
+import '@formatjs/intl-locale/polyfill';
+
 import { createTranslationFile, createLanguage } from './runtime';
 
 const createDemoTranslationFile = () =>

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -1,23 +1,35 @@
 import { createTranslationFile, createLanguage } from './runtime';
 
+const createDemoTranslationFile = () =>
+  createTranslationFile<
+    'en' | 'fr',
+    {
+      vocabPublishDate: {
+        params: { publishDate: Date | number };
+        returnType: string;
+      };
+    }
+  >({
+    en: createLanguage({
+      vocabPublishDate: 'Vocab was published on {publishDate, date, small}',
+    }),
+    fr: createLanguage({
+      vocabPublishDate: 'Vocab a été publié le {publishDate, date, medium}',
+    }),
+  });
+
 describe('createTranslationFile', () => {
-  it('should return TranslationModules', () => {
-    const translations = createTranslationFile<
-      'en' | 'fr',
-      {
-        vocabPublishDate: {
-          params: { publishDate: Date | number };
-          returnType: string;
-        };
-      }
-    >({
-      en: createLanguage({
-        vocabPublishDate: 'Vocab was published on {publishDate, date, small}',
+  it('should return TranslationModules with language as locale', () => {
+    const translations = createDemoTranslationFile();
+    const translationModule = translations.getMessages('en');
+    expect(
+      translationModule?.vocabPublishDate.format({
+        publishDate: 1605847714000,
       }),
-      fr: createLanguage({
-        vocabPublishDate: 'Vocab a été publié le {publishDate, date, medium}',
-      }),
-    });
+    ).toBe('Vocab was published on 11/20/2020');
+  });
+  it('should return TranslationModules with en-AU locale', () => {
+    const translations = createDemoTranslationFile();
     const translationModule = translations.getMessages('en', 'en-AU');
     expect(
       translationModule?.vocabPublishDate.format({
@@ -25,23 +37,17 @@ describe('createTranslationFile', () => {
       }),
     ).toBe('Vocab was published on 20/11/2020');
   });
+  it('should return TranslationModules with en-US locale', () => {
+    const translations = createDemoTranslationFile();
+    const translationModule = translations.getMessages('en', 'en-AU');
+    expect(
+      translationModule?.vocabPublishDate.format({
+        publishDate: 1605847714000,
+      }),
+    ).toBe('Vocab was published on 11/20/2020');
+  });
   it('should require parameters to be passed in', () => {
-    const translations = createTranslationFile<
-      'en' | 'fr',
-      {
-        vocabPublishDate: {
-          params: { publishDate: Date | number };
-          returnType: string;
-        };
-      }
-    >({
-      en: createLanguage({
-        vocabPublishDate: 'Vocab was published on {publishDate, date, small}',
-      }),
-      fr: createLanguage({
-        vocabPublishDate: 'Vocab a été publié le {publishDate, date, medium}',
-      }),
-    });
+    const translations = createDemoTranslationFile();
     const translationModule = translations.getMessages('en', 'en-AU');
     expect(
       // @ts-expect-error Missing params parameter

--- a/packages/core/src/runtime.test.ts
+++ b/packages/core/src/runtime.test.ts
@@ -19,9 +19,18 @@ const createDemoTranslationFile = () =>
   });
 
 describe('createTranslationFile', () => {
+  it('should return translations as a promise', async () => {
+    const translations = createDemoTranslationFile();
+    const translationModule = await translations.getMessages('en');
+    expect(
+      translationModule?.vocabPublishDate.format({
+        publishDate: 1605847714000,
+      }),
+    ).toBe('Vocab was published on 11/20/2020');
+  });
   it('should return TranslationModules with language as locale', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en');
+    const translationModule = translations.getLoadedMessages('en');
     expect(
       translationModule?.vocabPublishDate.format({
         publishDate: 1605847714000,
@@ -34,7 +43,7 @@ describe('createTranslationFile', () => {
   // eslint-disable-next-line jest/no-disabled-tests
   it.skip('should return TranslationModules with en-AU locale', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en', 'en-AU');
+    const translationModule = translations.getLoadedMessages('en', 'en-AU');
     expect(
       translationModule?.vocabPublishDate.format({
         publishDate: 1605847714000,
@@ -43,7 +52,7 @@ describe('createTranslationFile', () => {
   });
   it('should return TranslationModules with en-US locale', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en', 'en-US');
+    const translationModule = translations.getLoadedMessages('en', 'en-US');
     expect(
       translationModule?.vocabPublishDate.format({
         publishDate: 1605847714000,
@@ -52,7 +61,7 @@ describe('createTranslationFile', () => {
   });
   it('should require parameters to be passed in', () => {
     const translations = createDemoTranslationFile();
-    const translationModule = translations.getMessages('en');
+    const translationModule = translations.getLoadedMessages('en');
     expect(
       // @ts-expect-error Missing params parameter
       () => translationModule?.vocabPublishDate.format(),

--- a/packages/core/src/runtime.ts
+++ b/packages/core/src/runtime.ts
@@ -2,6 +2,8 @@ import { TranslationModule, TranslationMessagesByKey } from '@vocab/types';
 
 import { getParsedICUMessages } from './icu-handler';
 
+export { createTranslationFile } from './translation-file';
+
 export const createLanguage = (
   module: TranslationMessagesByKey,
 ): TranslationModule<any> => ({

--- a/packages/core/src/translation-file.ts
+++ b/packages/core/src/translation-file.ts
@@ -1,0 +1,49 @@
+import {
+  TranslationModule,
+  TranslationModuleByLanguage,
+  ParsedICUMessages,
+  LanguageName,
+  TranslationRequirementsByKey,
+} from '@vocab/types';
+
+export function createTranslationFile<
+  Language extends LanguageName,
+  RequirementsByKey extends TranslationRequirementsByKey
+>(
+  translationsByLanguage: TranslationModuleByLanguage<
+    Language,
+    RequirementsByKey
+  >,
+): {
+  getMessages: (
+    language: Language,
+    locale: string,
+  ) => ParsedICUMessages<RequirementsByKey> | null;
+  load: (language: Language) => Promise<void>;
+} {
+  function getByLanguage(
+    language: Language,
+  ): TranslationModule<RequirementsByKey> {
+    const translationModule = translationsByLanguage[language];
+    if (!translationModule) {
+      throw new Error(
+        `Attempted to retrieve translations for unknown language "${language}"`,
+      );
+    }
+    return translationModule;
+  }
+
+  return {
+    getMessages(
+      language: Language,
+      locale: string,
+    ): ParsedICUMessages<RequirementsByKey> | null {
+      const translationModule = getByLanguage(language);
+      return translationModule.getValue(locale) || null;
+    },
+    load(language: Language): Promise<void> {
+      const translationModule = getByLanguage(language);
+      return translationModule.load();
+    },
+  };
+}

--- a/packages/core/src/translation-file.ts
+++ b/packages/core/src/translation-file.ts
@@ -17,7 +17,7 @@ export function createTranslationFile<
 ): {
   getMessages: (
     language: Language,
-    locale: string,
+    locale?: string,
   ) => ParsedICUMessages<RequirementsByKey> | null;
   load: (language: Language) => Promise<void>;
 } {
@@ -36,10 +36,10 @@ export function createTranslationFile<
   return {
     getMessages(
       language: Language,
-      locale: string,
+      locale?: string,
     ): ParsedICUMessages<RequirementsByKey> | null {
       const translationModule = getByLanguage(language);
-      return translationModule.getValue(locale) || null;
+      return translationModule.getValue(locale || language) || null;
     },
     load(language: Language): Promise<void> {
       const translationModule = getByLanguage(language);

--- a/packages/core/translation-file/package.json
+++ b/packages/core/translation-file/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/vocab-core-translation-file.cjs.js",
+  "module": "dist/vocab-core-translation-file.esm.js"
+}

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -80,7 +80,7 @@ export function useTranslations<
   // TranslationFile<Language, Translations>['__translatedLanguageRequirements']
   const { language, locale } = useLanguage();
   const [, forceRender] = useReducer((s: number) => s + 1, 0);
-  const translationsObject = translations.getMessages(
+  const translationsObject = translations.getLoadedMessages(
     language as any,
     locale || language,
   );

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,9 +17,7 @@ export type TranslationRequirementsByKey = Record<
 /**
  * StrictParsedICUMessage A limited strictly typed format from intl-messageformat
  */
-export interface StrictParsedICUMessage<
-  Requirements extends TranslationRequirements
-> {
+interface StrictParsedICUMessage<Requirements extends TranslationRequirements> {
   format: Requirements['params'] extends Record<string, any>
     ? (params: Requirements['params']) => Requirements['returnType']
     : () => Requirements['returnType'];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -55,6 +55,10 @@ export type TranslationFile<
   getMessages: (
     language: Language,
     locale?: string,
+  ) => Promise<ParsedICUMessages<RequirementsByKey>>;
+  getLoadedMessages: (
+    language: Language,
+    locale?: string,
   ) => ParsedICUMessages<RequirementsByKey> | null;
   load: (language: Language) => Promise<void>;
 };

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -56,7 +56,7 @@ export type TranslationFile<
 > = {
   getMessages: (
     language: Language,
-    locale: string,
+    locale?: string,
   ) => ParsedICUMessages<RequirementsByKey> | null;
   load: (language: Language) => Promise<void>;
 };

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -87,14 +87,14 @@ export default async function vocabLoader(this: LoaderContext) {
   );
 
   const result = `
-      import { createLanguage } from '@vocab/webpack/${target}';
+      import { createLanguage, createTranslationFile } from '@vocab/webpack/${target}';
 
-      export default {
+      export default createTranslationFile({
           ${renderLanguageLoader(config.devLanguage)},
           ${getAltLanguages(config)
             .map((altLanguage) => renderLanguageLoader(altLanguage))
             .join(',')}
-      };
+      });
     `;
   trace('Created translation file', result);
 

--- a/packages/webpack/src/web.ts
+++ b/packages/webpack/src/web.ts
@@ -1,6 +1,8 @@
 import type { TranslationModule, TranslationMessagesByKey } from '@vocab/types';
 import { getParsedICUMessages } from '@vocab/core/icu-handler';
 
+export { createTranslationFile } from '@vocab/core/translation-file';
+
 export const createLanguage = (
   moduleId: string,
   loadImport: () => Promise<any>,

--- a/tests/E2E.test.ts
+++ b/tests/E2E.test.ts
@@ -132,4 +132,53 @@ describe('E2E', () => {
       server.close();
     });
   });
+
+  describe('Direct with plugin', () => {
+    let server: TestServer;
+
+    beforeAll(async () => {
+      const config = resolveConfigSync(
+        require.resolve('fixture-direct/vocab.config.js'),
+      );
+
+      if (!config) {
+        throw new Error(`Can't resolve "fixture-direct" vocab config`);
+      }
+
+      await compile({}, config);
+      server = await startFixture('fixture-direct');
+    });
+
+    beforeEach(async () => {
+      await page.goto(server.url);
+    });
+
+    it('should default to en-US english', async () => {
+      await page.click('#show-message');
+      await page.click('#update-message');
+
+      const syncMessage = await page.waitForSelector('#sync-message');
+      const asyncMessage = await page.waitForSelector('#async-message');
+
+      await expect(syncMessage).toMatch('Hello Syncronously');
+      await expect(asyncMessage).toMatch('Hello Asyncronously');
+      await expect(syncMessage).toMatch('Vocab was published on 11/20/2020');
+    });
+    it('should switch to french', async () => {
+      await page.click('#toggle-language');
+
+      await page.click('#show-message');
+      await page.click('#update-message');
+
+      const syncMessage = await page.waitForSelector('#sync-message');
+      const asyncMessage = await page.waitForSelector('#async-message');
+
+      await expect(syncMessage).toMatch('Bonjour Syncronously');
+      await expect(asyncMessage).toMatch('Bonjour Asyncronously');
+    });
+
+    afterAll(() => {
+      server.close();
+    });
+  });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,6 +5113,11 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
+full-icu@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.1.tgz#e67fdf58523f1d1e0d9143b1542fe2024c1c8997"
+  integrity sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==
+
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5113,11 +5113,6 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-full-icu@^1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/full-icu/-/full-icu-1.3.1.tgz#e67fdf58523f1d1e0d9143b1542fe2024c1c8997"
-  integrity sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==
-
 function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,10 +9,15 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/compat-data@^7.12.1", "@babel/compat-data@^7.12.5":
+"@babel/compat-data@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
   integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
+
+"@babel/compat-data@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.7.tgz#9329b4782a7d6bbd7eef57e11addf91ee3ef1e41"
+  integrity sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
 
 "@babel/core@^7.1.0", "@babel/core@^7.7.5":
   version "7.12.7"
@@ -99,7 +104,7 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-compilation-targets@^7.12.1":
+"@babel/helper-compilation-targets@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz#cb470c76198db6a24e9dbc8987275631e5d29831"
   integrity sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
@@ -175,7 +180,7 @@
   dependencies:
     "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1":
+"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
@@ -261,10 +266,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
+"@babel/helper-validator-identifier@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz#c9a1f021917dcb5ccf0d4e453e399022981fc9ed"
+  integrity sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+
 "@babel/helper-validator-option@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.1.tgz#175567380c3e77d60ff98a54bb015fe78f2178d9"
   integrity sha512-YpJabsXlJVWP0USHjnC/AQDTLlZERbON577YUVO/wLpqyj6HAtVYnWaQaN0iUN+1/tWn3c+uKKXjRut5115Y2A==
+
+"@babel/helper-validator-option@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.12.11.tgz#d66cb8b7a3e7fe4c6962b32020a131ecf0847f4f"
+  integrity sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.12.3"
@@ -361,10 +376,10 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
 
-"@babel/plugin-proposal-numeric-separator@^7.12.1":
-  version "7.12.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz#b1ce757156d40ed79d59d467cb2b154a5c4149ba"
-  integrity sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==
+"@babel/plugin-proposal-numeric-separator@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.7.tgz#8bf253de8139099fea193b297d23a9d406ef056b"
+  integrity sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
@@ -386,10 +401,10 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-optional-catch-binding" "^7.8.0"
 
-"@babel/plugin-proposal-optional-chaining@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.1.tgz#cce122203fc8a32794296fc377c6dedaf4363797"
-  integrity sha512-c2uRpY6WzaVDzynVY9liyykS+kVU+WRZPMPYpkelXH8KBt1oXoI89kPbZKKG/jDT5UK92FTW2fZkZaJhdiBabw==
+"@babel/plugin-proposal-optional-chaining@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.12.7.tgz#e02f0ea1b5dc59d401ec16fb824679f683d3303c"
+  integrity sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
@@ -546,10 +561,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-block-scoping@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz#f0ee727874b42a208a48a586b84c3d222c2bbef1"
-  integrity sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==
+"@babel/plugin-transform-block-scoping@^7.12.11":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.12.tgz#d93a567a152c22aea3b1929bb118d1d0a175cdca"
+  integrity sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -769,6 +784,15 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
+"@babel/plugin-transform-runtime@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.12.10.tgz#af0fded4e846c4b37078e8e5d06deac6cd848562"
+  integrity sha512-xOrUfzPxw7+WDm9igMgQCbO3cJKymX7dFdsgRr1eu9n3KjjyU4pptIXbXPseQDquw+W+RuJEJMHKHNsPNNm3CA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.5"
+    "@babel/helper-plugin-utils" "^7.10.4"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz#0bf9cac5550fce0cfdf043420f661d645fdc75e3"
@@ -784,13 +808,12 @@
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
-"@babel/plugin-transform-sticky-regex@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.1.tgz#5c24cf50de396d30e99afc8d1c700e8bce0f5caf"
-  integrity sha512-CiUgKQ3AGVk7kveIaPEET1jNDhZZEl1RPMWdTBE1799bdz++SwqDHStmxfCtDfBhQgCl38YRiSnrMuUMZIWSUQ==
+"@babel/plugin-transform-sticky-regex@^7.12.7":
+  version "7.12.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.12.7.tgz#560224613ab23987453948ed21d0b0b193fa7fad"
+  integrity sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-regex" "^7.10.4"
 
 "@babel/plugin-transform-template-literals@^7.12.1":
   version "7.12.1"
@@ -799,10 +822,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-transform-typeof-symbol@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.1.tgz#9ca6be343d42512fbc2e68236a82ae64bc7af78a"
-  integrity sha512-EPGgpGy+O5Kg5pJFNDKuxt9RdmTgj5sgrus2XVeMp/ZIbOESadgILUbm50SNpghOh3/6yrbsH+NB5+WJTmsA7Q==
+"@babel/plugin-transform-typeof-symbol@^7.12.10":
+  version "7.12.10"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.12.10.tgz#de01c4c8f96580bd00f183072b0d0ecdcf0dec4b"
+  integrity sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -830,16 +853,16 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/preset-env@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.1.tgz#9c7e5ca82a19efc865384bb4989148d2ee5d7ac2"
-  integrity sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==
+"@babel/preset-env@^7.12.11":
+  version "7.12.11"
+  resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.12.11.tgz#55d5f7981487365c93dbbc84507b1c7215e857f9"
+  integrity sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==
   dependencies:
-    "@babel/compat-data" "^7.12.1"
-    "@babel/helper-compilation-targets" "^7.12.1"
-    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/compat-data" "^7.12.7"
+    "@babel/helper-compilation-targets" "^7.12.5"
+    "@babel/helper-module-imports" "^7.12.5"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-validator-option" "^7.12.1"
+    "@babel/helper-validator-option" "^7.12.11"
     "@babel/plugin-proposal-async-generator-functions" "^7.12.1"
     "@babel/plugin-proposal-class-properties" "^7.12.1"
     "@babel/plugin-proposal-dynamic-import" "^7.12.1"
@@ -847,10 +870,10 @@
     "@babel/plugin-proposal-json-strings" "^7.12.1"
     "@babel/plugin-proposal-logical-assignment-operators" "^7.12.1"
     "@babel/plugin-proposal-nullish-coalescing-operator" "^7.12.1"
-    "@babel/plugin-proposal-numeric-separator" "^7.12.1"
+    "@babel/plugin-proposal-numeric-separator" "^7.12.7"
     "@babel/plugin-proposal-object-rest-spread" "^7.12.1"
     "@babel/plugin-proposal-optional-catch-binding" "^7.12.1"
-    "@babel/plugin-proposal-optional-chaining" "^7.12.1"
+    "@babel/plugin-proposal-optional-chaining" "^7.12.7"
     "@babel/plugin-proposal-private-methods" "^7.12.1"
     "@babel/plugin-proposal-unicode-property-regex" "^7.12.1"
     "@babel/plugin-syntax-async-generators" "^7.8.0"
@@ -868,7 +891,7 @@
     "@babel/plugin-transform-arrow-functions" "^7.12.1"
     "@babel/plugin-transform-async-to-generator" "^7.12.1"
     "@babel/plugin-transform-block-scoped-functions" "^7.12.1"
-    "@babel/plugin-transform-block-scoping" "^7.12.1"
+    "@babel/plugin-transform-block-scoping" "^7.12.11"
     "@babel/plugin-transform-classes" "^7.12.1"
     "@babel/plugin-transform-computed-properties" "^7.12.1"
     "@babel/plugin-transform-destructuring" "^7.12.1"
@@ -892,14 +915,14 @@
     "@babel/plugin-transform-reserved-words" "^7.12.1"
     "@babel/plugin-transform-shorthand-properties" "^7.12.1"
     "@babel/plugin-transform-spread" "^7.12.1"
-    "@babel/plugin-transform-sticky-regex" "^7.12.1"
+    "@babel/plugin-transform-sticky-regex" "^7.12.7"
     "@babel/plugin-transform-template-literals" "^7.12.1"
-    "@babel/plugin-transform-typeof-symbol" "^7.12.1"
+    "@babel/plugin-transform-typeof-symbol" "^7.12.10"
     "@babel/plugin-transform-unicode-escapes" "^7.12.1"
     "@babel/plugin-transform-unicode-regex" "^7.12.1"
     "@babel/preset-modules" "^0.1.3"
-    "@babel/types" "^7.12.1"
-    core-js-compat "^3.6.2"
+    "@babel/types" "^7.12.11"
+    core-js-compat "^3.8.0"
     semver "^5.5.0"
 
 "@babel/preset-modules@^0.1.3":
@@ -1004,6 +1027,15 @@
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.12.11":
+  version "7.12.12"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.12.tgz#4608a6ec313abbd87afa55004d373ad04a96c299"
+  integrity sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.12.11"
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
@@ -1225,6 +1257,11 @@
   dependencies:
     exec-sh "^0.3.2"
     minimist "^1.2.0"
+
+"@discoveryjs/json-ext@^0.5.0":
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.2.tgz#8f03a22a04de437254e8ce8cc84ba39689288752"
+  integrity sha512-HyYEUDeIj5rRQU2Hk5HTB2uHsbRQpF70nvMhVzi+VJR0X+xNEhjPui4/kBf3VeH/wqD28PT4sVOm8qqLjBrSZg==
 
 "@eslint/eslintrc@^0.2.1":
   version "0.2.1"
@@ -2425,6 +2462,23 @@
     "@webassemblyjs/wast-parser" "1.9.1"
     "@xtuc/long" "4.2.2"
 
+"@webpack-cli/configtest@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-1.0.0.tgz#2aff5f1ebc6f793c13ba9b2a701d180eab17f5ee"
+  integrity sha512-Un0SdBoN1h4ACnIO7EiCjWuyhNI0Jl96JC+63q6xi4HDUYRZn8Auluea9D+v9NWKc5J4sICVEltdBaVjLX39xw==
+
+"@webpack-cli/info@^1.2.1":
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-1.2.1.tgz#af98311f983d0b9fce7284cfcf1acaf1e9f4879c"
+  integrity sha512-fLnDML5HZ5AEKzHul8xLAksoKN2cibu6MgonkUj8R9V7bbeVRkd1XbGEGWrAUNYHbX1jcqCsDEpBviE5StPMzQ==
+  dependencies:
+    envinfo "^7.7.3"
+
+"@webpack-cli/serve@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-1.2.2.tgz#1f8eee44f96524756268f5e3f43e9d943f864d41"
+  integrity sha512-03GkWxcgFfm8+WIwcsqJb9agrSDNDDoxaNnexPnCCexP5SCE4IgFd9lNpSy+K2nFqVMpgTFw6SwbmVAVTndVew==
+
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -3001,7 +3055,7 @@ browser-process-hrtime@^1.0.0:
   resolved "https://registry.yarnpkg.com/browser-process-hrtime/-/browser-process-hrtime-1.0.0.tgz#3c9b4b7d782c8121e56f10106d84c0d0ffc94626"
   integrity sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
 
-browserslist@^4.14.5, browserslist@^4.14.6:
+browserslist@^4.14.5:
   version "4.14.7"
   resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.7.tgz#c071c1b3622c1c2e790799a37bb09473a4351cb6"
   integrity sha512-BSVRLCeG3Xt/j/1cCGj1019Wbty0H+Yvu2AOuZSuoaUWn3RatbL33Cxk+Q4jRMRAbOm0p7SLravLjpnT6s0vzQ==
@@ -3011,6 +3065,17 @@ browserslist@^4.14.5, browserslist@^4.14.6:
     electron-to-chromium "^1.3.591"
     escalade "^3.1.1"
     node-releases "^1.1.66"
+
+browserslist@^4.16.1:
+  version "4.16.1"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.1.tgz#bf757a2da376b3447b800a16f0f1c96358138766"
+  integrity sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
+  dependencies:
+    caniuse-lite "^1.0.30001173"
+    colorette "^1.2.1"
+    electron-to-chromium "^1.3.634"
+    escalade "^3.1.1"
+    node-releases "^1.1.69"
 
 bser@2.1.1:
   version "2.1.1"
@@ -3166,6 +3231,11 @@ caniuse-lite@^1.0.30001157:
   version "1.0.30001159"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001159.tgz#bebde28f893fa9594dadcaa7d6b8e2aa0299df20"
   integrity sha512-w9Ph56jOsS8RL20K9cLND3u/+5WASWdhC/PPrf+V3/HsM3uHOavWOR1Xzakbv4Puo/srmPHudkmCRWM7Aq+/UA==
+
+caniuse-lite@^1.0.30001173:
+  version "1.0.30001179"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001179.tgz#b0803883b4471a6c62066fb1752756f8afc699c8"
+  integrity sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -3330,6 +3400,15 @@ clone-deep@^0.2.4:
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
 
+clone-deep@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
+  integrity sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==
+  dependencies:
+    is-plain-object "^2.0.4"
+    kind-of "^6.0.2"
+    shallow-clone "^3.0.0"
+
 clone-response@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/clone-response/-/clone-response-1.0.2.tgz#d1dc973920314df67fbeb94223b4ee350239e96b"
@@ -3416,6 +3495,11 @@ commander@^5.1.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-5.1.0.tgz#46abbd1652f8e059bddaef99bbdcb2ad9cf179ae"
   integrity sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
 
+commander@^6.2.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.1.tgz#0792eb682dfbc325999bb2b84fddddba110ac73c"
+  integrity sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==
+
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -3495,12 +3579,12 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js-compat@^3.6.2:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.7.0.tgz#8479c5d3d672d83f1f5ab94cf353e57113e065ed"
-  integrity sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==
+core-js-compat@^3.8.0:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.8.3.tgz#9123fb6b9cad30f0651332dc77deba48ef9b0b3f"
+  integrity sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==
   dependencies:
-    browserslist "^4.14.6"
+    browserslist "^4.16.1"
     semver "7.0.0"
 
 core-js@^2.6.5:
@@ -3533,7 +3617,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
@@ -4006,6 +4090,11 @@ electron-to-chromium@^1.3.591:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.600.tgz#eb6aa7233ca1fbf0fa9b5943c0f1061b54a433bf"
   integrity sha512-QmdzrDk4eOoqkhld+XflF6znZHMFN120EfLdXgFP2TzvQuD6EABwKIjOIopx5hvVOIb1ELUPkEgs/rXo0iiXbw==
 
+electron-to-chromium@^1.3.634:
+  version "1.3.644"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.644.tgz#c89721733ec26b8d117275fb6b2acbeb3d45a6b6"
+  integrity sha512-N7FLvjDPADxad+OXXBuYfcvDvCBG0aW8ZZGr7G91sZMviYbnQJFxdSvUus4SJ0K7Q8dzMxE+Wx1d/CrJIIJ0sw==
+
 emittery@^0.7.1:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/emittery/-/emittery-0.7.2.tgz#25595908e13af0f5674ab419396e2fb394cdfa82"
@@ -4070,6 +4159,11 @@ env-ci@^5.0.2:
   dependencies:
     execa "^4.0.0"
     java-properties "^1.0.0"
+
+envinfo@^7.7.3:
+  version "7.7.3"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.7.3.tgz#4b2d8622e3e7366afb8091b23ed95569ea0208cc"
+  integrity sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==
 
 errno@^0.1.3:
   version "0.1.7"
@@ -4463,6 +4557,21 @@ execa@^4.0.0:
     signal-exit "^3.0.2"
     strip-final-newline "^2.0.0"
 
+execa@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-5.0.0.tgz#4029b0007998a841fbd1032e5f4de86a3c1e3376"
+  integrity sha512-ov6w/2LCiuyO4RLYGdpFGjkcs0wMTgGE8PrkTHikeUy5iJekXyPIKUjifk5CsE0pt7sMCrMZ3YNqoCj6idQOnQ==
+  dependencies:
+    cross-spawn "^7.0.3"
+    get-stream "^6.0.0"
+    human-signals "^2.1.0"
+    is-stream "^2.0.0"
+    merge-stream "^2.0.0"
+    npm-run-path "^4.0.1"
+    onetime "^5.1.2"
+    signal-exit "^3.0.3"
+    strip-final-newline "^2.0.0"
+
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -4658,6 +4767,11 @@ fast-memoize@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/fast-memoize/-/fast-memoize-2.5.2.tgz#79e3bb6a4ec867ea40ba0e7146816f6cdce9b57e"
   integrity sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==
+
+fastest-levenshtein@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz#9990f7d3a88cc5a9ffd1f1745745251700d497e2"
+  integrity sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==
 
 fastest-validator@^1.9.0:
   version "1.9.0"
@@ -5031,6 +5145,11 @@ get-stream@^5.0.0, get-stream@^5.1.0:
   integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
   dependencies:
     pump "^3.0.0"
+
+get-stream@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
+  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -5472,6 +5591,11 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
+human-signals@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
+  integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
@@ -5586,6 +5710,11 @@ internal-slot@^1.0.2:
     es-abstract "^1.17.0-next.1"
     has "^1.0.3"
     side-channel "^1.0.2"
+
+interpret@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
+  integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
 intl-messageformat-parser@6.0.16, intl-messageformat-parser@^6.0.16:
   version "6.0.16"
@@ -7232,6 +7361,11 @@ node-releases@^1.1.66:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.67.tgz#28ebfcccd0baa6aad8e8d4d8fe4cbc49ae239c12"
   integrity sha512-V5QF9noGFl3EymEwUYzO+3NTDpGfQB4ve6Qfnzf3UNydMhjQRVPR1DZTuvWiLzaFJYw2fmDwAfnRNEVb64hSIg==
 
+node-releases@^1.1.69:
+  version "1.1.70"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.70.tgz#66e0ed0273aa65666d7fe78febe7634875426a08"
+  integrity sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
+
 normalize-package-data@^2.3.2, normalize-package-data@^2.3.4, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
@@ -7288,7 +7422,7 @@ npm-run-path@^2.0.0:
   dependencies:
     path-key "^2.0.0"
 
-npm-run-path@^4.0.0:
+npm-run-path@^4.0.0, npm-run-path@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-4.0.1.tgz#b7ecd1e5ed53da8e37a55e1c2269e0b97ed748ea"
   integrity sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
@@ -7429,7 +7563,7 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
-onetime@^5.1.0:
+onetime@^5.1.0, onetime@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
   integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
@@ -8202,6 +8336,13 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+rechoir@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.7.0.tgz#32650fd52c21ab252aa5d65b19310441c7e03aca"
+  integrity sha512-ADsDEH2bvbjltXEP+hTIAmeFekTFK0V2BTxMkok6qILyAJEXV0AFfoWcAq4yfll5VdIMd/RVXq0lR+wQi5ZU3Q==
+  dependencies:
+    resolve "^1.9.0"
+
 redent@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/redent/-/redent-1.0.0.tgz#cf916ab1fd5f1f16dfb20822dd6ec7f730c2afde"
@@ -8446,7 +8587,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.0.0, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2:
+resolve@^1.0.0, resolve@^1.10.0, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.17.0, resolve@^1.18.1, resolve@^1.3.2, resolve@^1.9.0:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.19.0.tgz#1af5bf630409734a067cae29318aac7fa29a267c"
   integrity sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
@@ -8625,7 +8766,7 @@ sembear@^0.5.0:
     "@types/semver" "^6.0.1"
     semver "^6.3.0"
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -8729,6 +8870,13 @@ shallow-clone@^0.1.2:
     lazy-cache "^0.2.3"
     mixin-object "^2.0.1"
 
+shallow-clone@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
+  integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
+  dependencies:
+    kind-of "^6.0.2"
+
 shebang-command@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shebang-command/-/shebang-command-1.2.0.tgz#44aac65b695b03398968c39f363fee5deafdf1ea"
@@ -8766,7 +8914,7 @@ side-channel@^1.0.2:
     es-abstract "^1.18.0-next.0"
     object-inspect "^1.8.0"
 
-signal-exit@^3.0.0, signal-exit@^3.0.2:
+signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
@@ -9763,7 +9911,7 @@ uuid@^8.3.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
   integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
-v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1:
+v8-compile-cache@^2.0.3, v8-compile-cache@^2.1.1, v8-compile-cache@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz#9471efa3ef9128d2f7c6a7ca39c4dd6b5055b132"
   integrity sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
@@ -9890,6 +10038,26 @@ webidl-conversions@^6.1.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-6.1.0.tgz#9111b4d7ea80acd40f5270d666621afa78b69514"
   integrity sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
 
+webpack-cli@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-4.4.0.tgz#38c7fa01ea31510f5c490245dd1bb28018792f1b"
+  integrity sha512-/Qh07CXfXEkMu5S8wEpjuaw2Zj/CC0hf/qbTDp6N8N7JjdGuaOjZ7kttz+zhuJO/J5m7alQEhNk9lsc4rC6xgQ==
+  dependencies:
+    "@discoveryjs/json-ext" "^0.5.0"
+    "@webpack-cli/configtest" "^1.0.0"
+    "@webpack-cli/info" "^1.2.1"
+    "@webpack-cli/serve" "^1.2.2"
+    colorette "^1.2.1"
+    commander "^6.2.0"
+    enquirer "^2.3.6"
+    execa "^5.0.0"
+    fastest-levenshtein "^1.0.12"
+    import-local "^3.0.2"
+    interpret "^2.2.0"
+    rechoir "^0.7.0"
+    v8-compile-cache "^2.2.0"
+    webpack-merge "^5.7.3"
+
 webpack-dev-middleware@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/webpack-dev-middleware/-/webpack-dev-middleware-3.7.2.tgz#0019c3db716e3fa5cecbf64f2ab88a74bab331f3"
@@ -9947,6 +10115,14 @@ webpack-log@^2.0.0:
   dependencies:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
+
+webpack-merge@^5.7.3:
+  version "5.7.3"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-5.7.3.tgz#2a0754e1877a25a8bbab3d2475ca70a052708213"
+  integrity sha512-6/JUQv0ELQ1igjGDzHkXbVDRxkfA57Zw7PfiupdLFJYrgFqY5ZP8xxbpp2lU3EPwYx89ht5Z/aDkD40hFCm5AA==
+  dependencies:
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
 
 webpack-sources@^2.1.1:
   version "2.2.0"
@@ -10061,6 +10237,11 @@ widest-line@^2.0.0:
   integrity sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==
   dependencies:
     string-width "^2.1.1"
+
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/wildcard/-/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==
 
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,31 @@
   dependencies:
     tslib "^2.0.1"
 
+"@formatjs/ecma402-abstract@1.5.1":
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.5.1.tgz#629324d2bfdc570ed210fec7700ce20bbd872bed"
+  integrity sha512-io9XhgIpEbc6jSdn4QVnJeFaUzy6gS5fGiIRCUJ7QKqCNp69JS8EJPW8gCtvwz+JQtx2SJvhaMJbzz3rGkTXBA==
+  dependencies:
+    tslib "^2.0.1"
+
+"@formatjs/intl-getcanonicallocales@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-getcanonicallocales/-/intl-getcanonicallocales-1.5.3.tgz#b5978462340da1502502c3fde1c4abccff8f3b8e"
+  integrity sha512-QVBnSPZ32Y80wkXbf36hP9VbyklbOb8edppxFcgO9Lbd47zagllw65Y81QOHEn/j11JcTn2OhW0vea95LHvQmA==
+  dependencies:
+    cldr-core "38"
+    tslib "^2.0.1"
+
+"@formatjs/intl-locale@^2.4.13":
+  version "2.4.13"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-locale/-/intl-locale-2.4.13.tgz#f27d1525e116b305db3446974a0c3b11768f3ef4"
+  integrity sha512-hrglCuFjRpMrutmuL+Ck84KBxeHhouk7d5B/G9kqHL4zmrW6AsBwU+0KeyvareiY3MWzYZhQj1Nm3JEGulQRUQ==
+  dependencies:
+    "@formatjs/ecma402-abstract" "1.5.1"
+    "@formatjs/intl-getcanonicallocales" "1.5.3"
+    cldr-core "38"
+    tslib "^2.0.1"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -3349,6 +3374,11 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+cldr-core@38:
+  version "38.0.0"
+  resolved "https://registry.yarnpkg.com/cldr-core/-/cldr-core-38.0.0.tgz#f54a5dfd222c79a050f1fe8e87ad9764f16fb840"
+  integrity sha512-WkjA4zo5rLT/BWTZAxHJ0lJXwI33gCYucEz1+CpoI8Wu+rr5IrC57wyNXyrNNMdxfDE5RsWi/JCQ9qnG8sHTiw==
 
 clean-css@^4.2.3:
   version "4.2.3"


### PR DESCRIPTION
Formalize the contract as described in the README.md

- Created name for `Requirements` as the transport mechanism of params and returnType. Previously `Translations`. Removed unused 'message' from this
- Exported createTranslations through the different runtimes to allow easier consumption as we don't own the consumer code
- Created and disabled locale test due to current limitations in CI. These may be achievable but attempted solutions haven't work so far.