### PR TITLE
Use anchor tag in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Vocab will automatically parse these strings as ICU messages, identify the requi
 ```tsx
 t('my key with param', { name: 'Vocab' });
 t('my key with component', {
-  Link: (children) => <Link href="/foo">{children}</Link>
+  Link: (children) => <a href="/foo">{children}</a>
 });
 ```
 


### PR DESCRIPTION
The use of a Link component might confuse the reader into thinking there is a correlation between the "Link" method name and the link component.

Using an anchor tag simplies the example.