### PR TITLE
Remove compiler target warning

### DIFF
--- a/.changeset/kind-chefs-brush.md
+++ b/.changeset/kind-chefs-brush.md
@@ -1,0 +1,5 @@
+---
+'@vocab/webpack': patch
+---
+
+Remove compiler target warning

--- a/packages/webpack/src/index.ts
+++ b/packages/webpack/src/index.ts
@@ -28,16 +28,6 @@ export class VocabWebpackPlugin {
     trace(
       `Applying plugin: ${compiler.options.name} (${compiler.options.target})`,
     );
-    if (compiler.options.target && compiler.options.target !== 'web') {
-      // eslint-disable-next-line no-console
-      console.error(
-        `Vocab plugin is only intended to be used on web builds. Received target ${
-          compiler.options.target
-        } for ${
-          compiler.options.name || 'unnamed build'
-        }. Did you add Vocab to the correct config?`,
-      );
-    }
     if (!compiler.options.module) {
       // @ts-expect-error Support for older versions of webpack that may not have module defined at this stage
       compiler.options.module = { rules: [] };


### PR DESCRIPTION
As webpack now supports more complex targets this check no longer makes sense. 