### PR TITLE
Don't fail when phrase doesn't have translations for a configured language

### DIFF
--- a/.changeset/unlucky-wolves-kick.md
+++ b/.changeset/unlucky-wolves-kick.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': patch
+---
+
+`vocab pull` no longer errors when phrase returns no translations for a configured language

--- a/packages/core/src/load-translations.ts
+++ b/packages/core/src/load-translations.ts
@@ -57,7 +57,7 @@ function getLanguageFallbacks({
   return languageFallbackMap;
 }
 
-export function getLanguageHierarcy({
+function getLanguageHierarchy({
   languages,
 }: {
   languages: Array<LanguageTarget>;
@@ -164,7 +164,7 @@ function loadAltLanguageFile(
 ): TranslationsByKey {
   const result = {};
 
-  const languageHierarchy = getLanguageHierarcy({ languages }).get(
+  const languageHierarchy = getLanguageHierarchy({ languages }).get(
     languageName,
   );
 
@@ -183,7 +183,7 @@ function loadAltLanguageFile(
   }
 
   trace(
-    `Loading alt language file with precendence: ${fallbackLanguages
+    `Loading alt language file with precedence: ${fallbackLanguages
       .slice()
       .reverse()
       .join(' -> ')}`,

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -80,7 +80,6 @@ export async function callPhrase(
     options,
   )
     .then((result) => {
-      // console.log('Result:', result);
       if (Array.isArray(result)) {
         console.log('Result length:', result.length);
       }

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -59,41 +59,44 @@ export async function pull(
     );
 
     for (const alternativeLanguage of alternativeLanguages) {
-      const altTranslations = {
-        ...loadedTranslation.languages[alternativeLanguage],
-      };
-      const phraseAltTranslations = allPhraseTranslations[alternativeLanguage];
+      if (alternativeLanguage in allPhraseTranslations) {
+        const altTranslations = {
+          ...loadedTranslation.languages[alternativeLanguage],
+        };
+        const phraseAltTranslations =
+          allPhraseTranslations[alternativeLanguage];
 
-      for (const key of localKeys) {
-        const phraseKey = getUniqueKey(key, loadedTranslation.namespace);
-        const phraseTranslationMessage =
-          phraseAltTranslations[phraseKey]?.message;
+        for (const key of localKeys) {
+          const phraseKey = getUniqueKey(key, loadedTranslation.namespace);
+          const phraseTranslationMessage =
+            phraseAltTranslations[phraseKey]?.message;
 
-        if (!phraseTranslationMessage) {
-          trace(
-            `Missing translation. No translation for key ${key} in phrase as ${phraseKey} in language ${alternativeLanguage}.`,
-          );
-          continue;
+          if (!phraseTranslationMessage) {
+            trace(
+              `Missing translation. No translation for key ${key} in phrase as ${phraseKey} in language ${alternativeLanguage}.`,
+            );
+            continue;
+          }
+
+          altTranslations[key] = {
+            ...altTranslations[key],
+            message: phraseTranslationMessage,
+          };
         }
 
-        altTranslations[key] = {
-          ...altTranslations[key],
-          message: phraseTranslationMessage,
-        };
+        const altTranslationFilePath = getAltLanguageFilePath(
+          loadedTranslation.filePath,
+          alternativeLanguage,
+        );
+
+        await mkdir(path.dirname(altTranslationFilePath), {
+          recursive: true,
+        });
+        await writeFile(
+          altTranslationFilePath,
+          `${JSON.stringify(altTranslations, null, 2)}\n`,
+        );
       }
-
-      const altTranslationFilePath = getAltLanguageFilePath(
-        loadedTranslation.filePath,
-        alternativeLanguage,
-      );
-
-      await mkdir(path.dirname(altTranslationFilePath), {
-        recursive: true,
-      });
-      await writeFile(
-        altTranslationFilePath,
-        `${JSON.stringify(altTranslations, null, 2)}\n`,
-      );
     }
   }
 }


### PR DESCRIPTION
The fix is [this if statement](https://github.com/seek-oss/vocab/pull/76/files#diff-ce5339b9f02ea2943a9485adc7774200467e71e3f1afc1f48bcba107f285b5e8R62). The added test was failing before the change.