### PR TITLE
Fix fallback language ordering

### DIFF
--- a/.changeset/late-gorillas-cheer.md
+++ b/.changeset/late-gorillas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+Dev language translations no longer take precedence over existing extended language translations.

--- a/.changeset/late-gorillas-cheer.md
+++ b/.changeset/late-gorillas-cheer.md
@@ -2,4 +2,4 @@
 '@vocab/core': patch
 ---
 
-Dev language translations no longer take precedence over existing extended language translations.
+Fix incorrect language hierarchy when an extended language extends another language

--- a/packages/core/src/load-translations.test.ts
+++ b/packages/core/src/load-translations.test.ts
@@ -1,0 +1,165 @@
+import {
+  getFallbackLanguageOrder,
+  getLanguageHierarchy,
+  loadAltLanguageFile,
+  mergeWithDevLanguageTranslation,
+} from './load-translations';
+import path from 'path';
+
+describe('mergeWithDevLanguage', () => {
+  const key = 'Hello';
+
+  describe('when the translation has a message for a key in the dev translation', () => {
+    it('should have a message from the translation', () => {
+      const thTranslation = { Hello: { message: 'Hello in Thai' } };
+      const devTranslation = { Hello: { message: 'Hello' } };
+
+      const mergedTranslations = mergeWithDevLanguageTranslation({
+        translation: thTranslation,
+        devTranslation,
+      });
+
+      expect(mergedTranslations[key]).toEqual({ message: 'Hello in Thai' });
+    });
+  });
+
+  describe('when the translation does not have a message for a key in the dev translation', () => {
+    it('should not have a message for the given key', () => {
+      const translation = {};
+      const devTranslation = { Hello: { message: 'Hello' } };
+
+      const mergedTranslations = mergeWithDevLanguageTranslation({
+        translation,
+        devTranslation,
+      });
+
+      expect(mergedTranslations[key]).toEqual(undefined);
+    });
+  });
+});
+
+describe('getLanguageHierarchy', () => {
+  it('should return a correct language hierarchy', () => {
+    expect(
+      getLanguageHierarchy({
+        languages: [
+          { name: 'en' },
+          { name: 'th', extends: 'en' },
+          { name: 'th-TH', extends: 'th' },
+          { name: 'en-AU', extends: 'en' },
+        ],
+      }),
+    ).toEqual(
+      new Map([
+        ['en', []],
+        ['th', ['en']],
+        ['th-TH', ['th', 'en']],
+        ['en-AU', ['en']],
+      ]),
+    );
+  });
+});
+
+describe('getFallbackLanguageOrder', () => {
+  const languages = [
+    { name: 'fr' },
+    { name: 'en' },
+    { name: 'th', extends: 'en' },
+    { name: 'th-TH', extends: 'th' },
+  ];
+  const languageName = 'th-TH';
+  const devLanguage = 'fr';
+
+  describe('fallbacks = none', () => {
+    it('should return just the requested language', () => {
+      const fallbacks = 'none';
+
+      expect(
+        getFallbackLanguageOrder({
+          languages,
+          languageName,
+          devLanguage,
+          fallbacks,
+        }),
+      ).toEqual(['th-TH']);
+    });
+  });
+
+  describe('fallbacks = valid', () => {
+    it('should return just the requested language', () => {
+      const fallbacks = 'valid';
+
+      expect(
+        getFallbackLanguageOrder({
+          languages,
+          languageName,
+          devLanguage,
+          fallbacks,
+        }),
+      ).toEqual(['en', 'th', 'th-TH']);
+    });
+  });
+
+  describe('fallbacks = all', () => {
+    it('should return just the requested language', () => {
+      const fallbacks = 'all';
+
+      expect(
+        getFallbackLanguageOrder({
+          languages,
+          languageName,
+          devLanguage,
+          fallbacks,
+        }),
+      ).toEqual(['fr', 'en', 'th', 'th-TH']);
+    });
+  });
+});
+
+describe('loadAltLanguageFile', () => {
+  describe('when a language extends a language that also extends another language', () => {
+    it('should resolve translation message correctly according to the fallback hierarchy', () => {
+      const filePath = path.join(
+        __dirname,
+        'test-translations/translations.json',
+      );
+      const devTranslation = {
+        Hello: { message: 'Hello in French' },
+        Goodbye: {
+          message: 'Goodbye in French',
+        },
+        Welcome: {
+          message: 'Welcome in French',
+        },
+        'Good morning': {
+          message: 'Good morning in French',
+        },
+      };
+
+      const thTHTranslations = loadAltLanguageFile(
+        {
+          filePath,
+          languageName: 'th-TH',
+          devTranslation,
+          fallbacks: 'all',
+        },
+        {
+          devLanguage: 'fr',
+          languages: [
+            { name: 'fr' },
+            { name: 'en' },
+            { name: 'th', extends: 'en' },
+            { name: 'th-TH', extends: 'th' },
+          ],
+        },
+      );
+
+      expect(thTHTranslations).toEqual({
+        Hello: { message: 'Hello in Thai' },
+        Goodbye: { message: 'Goodbye' },
+        Welcome: { message: 'Welcome in Thai-TH' },
+        'Good morning': { message: 'Good morning in French' },
+      });
+    });
+  });
+});

--- a/packages/core/src/test-translations/en.translations.json
+++ b/packages/core/src/test-translations/en.translations.json
@@ -1,0 +1,9 @@
+{
+  "Hello": { "message": "Hello" },
+  "Goodbye": {
+    "message": "Goodbye"
+  },
+  "Welcome": {
+    "message": "Welcome"
+  }
+}

--- a/packages/core/src/test-translations/th-TH.translations.json
+++ b/packages/core/src/test-translations/th-TH.translations.json
@@ -1,0 +1,1 @@
+{ "Welcome": { "message": "Welcome in Thai-TH" } }

--- a/packages/core/src/test-translations/th.translations.json
+++ b/packages/core/src/test-translations/th.translations.json
@@ -1,0 +1,1 @@
+{ "Hello": { "message": "Hello in Thai" } }

--- a/packages/core/src/validate/index.ts
+++ b/packages/core/src/validate/index.ts
@@ -8,7 +8,7 @@ import { getAltLanguages } from '../utils';
 export function findMissingKeys(
   loadedTranslation: LoadedTranslation,
   devLanguageName: LanguageName,
-  altLangauges: Array<LanguageName>,
+  altLanguages: Array<LanguageName>,
 ) {
   const devLanguage = loadedTranslation.languages[devLanguageName];
 
@@ -24,7 +24,7 @@ export function findMissingKeys(
   const requiredKeys = Object.keys(devLanguage);
 
   if (requiredKeys.length > 0) {
-    for (const altLanguageName of altLangauges) {
+    for (const altLanguageName of altLanguages) {
       const altLanguage = loadedTranslation.languages[altLanguageName] ?? {};
 
       for (const key of requiredKeys) {


### PR DESCRIPTION
Fixes a bug where dev language translations were taking precedence over other languages with translations earlier in the fallback ordering. The actual fix is just reversing the order of the language hierarchy array before spreading it [here](https://github.com/seek-oss/vocab/blob/fix-fallback-language-ordering/packages/core/src/load-translations.ts#L111).

Have added some tests for this case too.