### PR TITLE
add exports to core package

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,6 +3,21 @@
   "version": "1.1.0",
   "main": "dist/vocab-core.cjs.js",
   "module": "dist/vocab-core.esm.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "module": "./dist/vocab-core.esm.js",
+      "default": "./dist/vocab-core.cjs.js"
+    },
+    "./icu-handler": {
+      "module": "./icu-handler/dist/vocab-core-icu-handler.esm.js",
+      "default": "./icu-handler/dist/vocab-core-icu-handler.cjs.js"
+    },
+    "./runtime": {
+      "module": "./runtime/dist/vocab-core-runtime.esm.js",
+      "default": "./runtime/dist/vocab-core-runtime.cjs.js"
+    }
+  },
   "author": "SEEK",
   "license": "MIT",
   "preconstruct": {


### PR DESCRIPTION
This should fix #87 and move vocab to be more inline with Vanilla-Extract.