### PR TITLE
Improve error message when Phrase doesn't return any translations for the dev language

### DIFF
--- a/.changeset/lemon-jars-smash.md
+++ b/.changeset/lemon-jars-smash.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': patch
+---
+
+Improve error message when Phrase doesn't return any translations for the dev language

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -200,47 +200,7 @@ describe('pull translations', () => {
     it('should throw an error', async () => {
       await expect(runPhrase(options)).rejects.toThrowError(
         new Error(
-          'Phrase did not return any translations for dev language "en".\nEnsure you have configured your Phrase project for your dev language, and have pushed your translations.',
-        ),
-      );
-
-      expect(writeFile as jest.Mock).toHaveBeenCalledTimes(0);
-    });
-  });
-
-  describe('when pulling translations and there are no translations for the dev language', () => {
-    beforeEach(() => {
-      (pullAllTranslations as jest.Mock).mockClear();
-      (writeFile as jest.Mock).mockClear();
-      (pullAllTranslations as jest.Mock).mockImplementation(() =>
-        Promise.resolve({
-          en: {},
-          fr: {
-            'hello.mytranslations': {
-              message: 'merci',
-            },
-          },
-        }),
-      );
-    });
-
-    const options = {
-      languages: [{ name: 'en' }, { name: 'fr' }],
-      generatedLanguages: [
-        {
-          name: 'generatedLanguage',
-          extends: 'en',
-          generator: {
-            transformMessage: (message: string) => `[${message}]`,
-          },
-        },
-      ],
-    };
-
-    it('should throw an error', async () => {
-      await expect(runPhrase(options)).rejects.toThrowError(
-        new Error(
-          'Phrase did not return any translations for dev language "en".\nEnsure you have configured your Phrase project for your dev language, and have pushed your translations.',
+          'Phrase did not return any translations for dev language "en".\nEnsure you have configured your Phrase project for your dev language.',
         ),
       );
 

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -200,7 +200,7 @@ describe('pull translations', () => {
     it('should throw an error', async () => {
       await expect(runPhrase(options)).rejects.toThrowError(
         new Error(
-          'Phrase did not return any translations for dev language "en".\nEnsure you have configured your Phrase project for your dev language.',
+          `Phrase did not return any translations for the configured development language "en".\nPlease ensure this language is present in your Phrase project's configuration.`,
         ),
       );
 

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -31,19 +31,13 @@ export async function pull(
   );
 
   const phraseLanguages = Object.keys(allPhraseTranslations);
-  const phraseLanguagesWithTranslations = phraseLanguages.filter((language) => {
-    const phraseTranslationsForLanguage = allPhraseTranslations[language];
-    return Object.keys(phraseTranslationsForLanguage).length > 0;
-  });
 
   trace(
-    `Found Phrase translations for languages ${phraseLanguagesWithTranslations.join(
-      ', ',
-    )}`,
+    `Found Phrase translations for languages ${phraseLanguages.join(', ')}`,
   );
-  if (!phraseLanguagesWithTranslations.includes(config.devLanguage)) {
+  if (!phraseLanguages.includes(config.devLanguage)) {
     throw new Error(
-      `Phrase did not return any translations for dev language "${config.devLanguage}".\nEnsure you have configured your Phrase project for your dev language, and have pushed your translations.`,
+      `Phrase did not return any translations for dev language "${config.devLanguage}".\nEnsure you have configured your Phrase project for your dev language.`,
     );
   }
 

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -30,6 +30,23 @@ export async function pull(
     } and ${alternativeLanguages.join(', ')}`,
   );
 
+  const phraseLanguages = Object.keys(allPhraseTranslations);
+  const phraseLanguagesWithTranslations = phraseLanguages.filter((language) => {
+    const phraseTranslationsForLanguage = allPhraseTranslations[language];
+    return Object.keys(phraseTranslationsForLanguage).length > 0;
+  });
+
+  trace(
+    `Found Phrase translations for languages ${phraseLanguagesWithTranslations.join(
+      ', ',
+    )}`,
+  );
+  if (!phraseLanguagesWithTranslations.includes(config.devLanguage)) {
+    throw new Error(
+      `Phrase did not return any translations for dev language "${config.devLanguage}".\nEnsure you have configured your Phrase project for your dev language, and have pushed your translations.`,
+    );
+  }
+
   const allVocabTranslations = await loadAllTranslations(
     { fallbacks: 'none', includeNodeModules: false },
     config,

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -31,10 +31,10 @@ export async function pull(
   );
 
   const phraseLanguages = Object.keys(allPhraseTranslations);
-
   trace(
     `Found Phrase translations for languages ${phraseLanguages.join(', ')}`,
   );
+
   if (!phraseLanguages.includes(config.devLanguage)) {
     throw new Error(
       `Phrase did not return any translations for dev language "${config.devLanguage}".\nEnsure you have configured your Phrase project for your dev language.`,

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -37,7 +37,7 @@ export async function pull(
 
   if (!phraseLanguages.includes(config.devLanguage)) {
     throw new Error(
-      `Phrase did not return any translations for dev language "${config.devLanguage}".\nEnsure you have configured your Phrase project for your dev language.`,
+      `Phrase did not return any translations for the configured development language "${config.devLanguage}".\nPlease ensure this language is present in your Phrase project's configuration.`,
     );
   }
 


### PR DESCRIPTION
When pulling translation from Phrase, if no translations were found for the dev language the user would see a TypeError about reading properties of `undefined`, which isn't particularly helpful.

This change adds a check that the languages that come back from Phrase when fetching translations includes your dev language, throwing a helpful error if the dev language is missing.