### PR TITLE
Add option to delete unused keys when pushing translations

### DIFF
--- a/.changeset/happy-games-return.md
+++ b/.changeset/happy-games-return.md
@@ -3,3 +3,19 @@
 ---
 
 Add an optional `deleteUnusedKeys` flag to the `push` function. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.
+
+**EXAMPLE USAGE**:
+
+```js
+import { push } from '@vocab/phrase';
+
+const vocabConfig = {
+  devLanguage: 'en',
+  language: ['en', 'fr']
+};
+
+await push(
+  { branch: 'myBranch', deleteUnusedKeys: true },
+  vocabConfig
+);
+```

--- a/.changeset/happy-games-return.md
+++ b/.changeset/happy-games-return.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': minor
+---
+
+Add an optional `deleteUnusedKeys` flag to the `push` function. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.

--- a/.changeset/sweet-otters-promise.md
+++ b/.changeset/sweet-otters-promise.md
@@ -3,3 +3,9 @@
 ---
 
 Add an optional `delete-unused-keys` flag to the `push` command. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.
+
+**EXAMPLE USAGE**:
+
+```bash
+vocab push --delete-unused-keys
+```

--- a/.changeset/sweet-otters-promise.md
+++ b/.changeset/sweet-otters-promise.md
@@ -1,0 +1,5 @@
+---
+'@vocab/cli': minor
+---
+
+Add an optional `deleteUnusedKeys` flag to the `push` function. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.

--- a/.changeset/sweet-otters-promise.md
+++ b/.changeset/sweet-otters-promise.md
@@ -2,4 +2,4 @@
 '@vocab/cli': minor
 ---
 
-Add an optional `deleteUnusedKeys` flag to the `push` function. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.
+Add an optional `delete-unused-keys` flag to the `push` command. If set to `true`, unused keys will be deleted from Phrase after translations are pushed.

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ Vocab can be used to synchronize your translations with translations from a remo
 
 ```bash
 $ vocab push --branch my-branch
+$ vocab push --branch my-branch --delete-unused-keys
 $ vocab pull --branch my-branch
 ```
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -29,7 +29,15 @@ yargs(process.argv.slice(2))
   })
   .command({
     command: 'push',
-    builder: () => yargs.options({ branch: branchDefinition }),
+    builder: () =>
+      yargs.options({
+        branch: branchDefinition,
+        deleteUnusedKeys: {
+          type: 'boolean',
+          describe: 'Whether or not to delete unused keys after pushing',
+          default: false,
+        },
+      }),
     handler: async (options) => {
       await push(options, config!);
     },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -32,7 +32,7 @@ yargs(process.argv.slice(2))
     builder: () =>
       yargs.options({
         branch: branchDefinition,
-        deleteUnusedKeys: {
+        'delete-unused-keys': {
           type: 'boolean',
           describe: 'Whether or not to delete unused keys after pushing',
           default: false,

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -31,14 +31,14 @@ function _callPhrase(path: string, options: Parameters<typeof fetch>[1] = {}) {
         'X-Rate-Limit-Reset',
       )} seconds remaining})`,
     );
-    console.log('\nLink:', response.headers.get('Link'), '\n');
+    trace('\nLink:', response.headers.get('Link'), '\n');
     // Print All Headers:
     // console.log(Array.from(r.headers.entries()));
 
     try {
       const result = await response.json();
 
-      console.log(`Internal Result (Length: ${result.length})\n`);
+      trace(`Internal Result (Length: ${result.length})\n`);
 
       if (
         (!options.method || options.method === 'GET') &&
@@ -48,10 +48,10 @@ function _callPhrase(path: string, options: Parameters<typeof fetch>[1] = {}) {
           response.headers.get('Link')?.match(/<([^>]*)>; rel=next/) ?? [];
 
         if (!nextPageUrl) {
-          throw new Error('Cant parse next page URL');
+          throw new Error("Can't parse next page URL");
         }
 
-        console.log('Results recieved with next page: ', nextPageUrl);
+        console.log('Results received with next page: ', nextPageUrl);
 
         const nextPageResult = (await _callPhrase(nextPageUrl, options)) as any;
 
@@ -101,13 +101,16 @@ export async function pullAllTranslations(
       content: string;
     }>
   >(`translations?branch=${branch}&per_page=100`);
+
   const translations: TranslationsByLanguage = {};
+
   for (const r of phraseResult) {
     if (!translations[r.locale.code]) {
       translations[r.locale.code] = {};
     }
     translations[r.locale.code][r.key.name] = { message: r.content };
   }
+
   return translations;
 }
 
@@ -128,7 +131,7 @@ export async function pushTranslationsByLocale(
   formData.append('branch', branch);
   formData.append('update_translations', 'true');
 
-  trace('Starting to upload:', locale);
+  log('Starting to upload:', locale, '\n');
 
   const { id } = await callPhrase<{ id: string }>(`uploads`, {
     method: 'POST',
@@ -173,5 +176,6 @@ export async function ensureBranch(branch: string) {
     },
     body: JSON.stringify({ name: branch }),
   });
-  trace('Created branch:', branch);
+
+  log('Created branch:', branch);
 }

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -146,16 +146,20 @@ export async function deleteUnusedKeys(
   branch: string,
 ) {
   const query = `unmentioned_in_upload:${uploadId}`;
-  const result = await callPhrase<{ records_affected: number }>('keys', {
-    method: 'DELETE',
-    headers: {
-      'Content-Type': 'application/json',
+  const { records_affected } = await callPhrase<{ records_affected: number }>(
+    'keys',
+    {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ branch, locale_id: locale, q: query }),
     },
-    body: JSON.stringify({ branch, locale_id: locale, q: query }),
-  });
+  );
+
   log(
     'Successfully deleted',
-    result.records_affected,
+    records_affected,
     'unused keys from branch',
     branch,
   );

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -14,6 +14,7 @@ import { trace } from './logger';
 
 interface PullOptions {
   branch?: string;
+  deleteUnusedKeys?: boolean;
 }
 
 export async function pull(

--- a/packages/phrase/src/push-translations.test.ts
+++ b/packages/phrase/src/push-translations.test.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { push } from './push-translations';
-import { pushTranslationsByLocale } from './phrase-api';
+import { pushTranslationsByLocale, deleteUnusedKeys } from './phrase-api';
 import { writeFile } from './file';
 
 jest.mock('./file', () => ({
@@ -11,11 +11,14 @@ jest.mock('./file', () => ({
 jest.mock('./phrase-api', () => ({
   ensureBranch: jest.fn(() => Promise.resolve()),
   pushTranslationsByLocale: jest.fn(() => Promise.resolve({ en: {}, fr: {} })),
+  deleteUnusedKeys: jest.fn(() => Promise.resolve()),
 }));
 
-function runPhrase() {
+const uploadId = '1234';
+
+function runPhrase(config: { deleteUnusedKeys: boolean }) {
   return push(
-    { branch: 'tester' },
+    { branch: 'tester', deleteUnusedKeys: config.deleteUnusedKeys },
     {
       devLanguage: 'en',
       languages: [{ name: 'en' }, { name: 'fr' }],
@@ -34,44 +37,114 @@ function runPhrase() {
 }
 
 describe('push', () => {
-  beforeEach(() => {
-    (pushTranslationsByLocale as jest.Mock).mockClear();
-    (writeFile as jest.Mock).mockClear();
+  describe('when deleteUnusedKeys is false', () => {
+    const config = { deleteUnusedKeys: false };
+
+    beforeEach(() => {
+      (pushTranslationsByLocale as jest.Mock).mockClear();
+      (writeFile as jest.Mock).mockClear();
+      (deleteUnusedKeys as jest.Mock).mockClear();
+
+      (pushTranslationsByLocale as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ uploadId }),
+      );
+    });
+
+    it('should resolve', async () => {
+      await expect(runPhrase(config)).resolves.toBeUndefined();
+
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should update keys', async () => {
+      await expect(runPhrase(config)).resolves.toBeUndefined();
+
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
+        {
+          'hello.mytranslations': {
+            message: 'Hello',
+          },
+          'world.mytranslations': {
+            message: 'world',
+          },
+        },
+        'en',
+        'tester',
+      );
+
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
+        {
+          'hello.mytranslations': {
+            message: 'Bonjour',
+          },
+          'world.mytranslations': {
+            message: 'monde',
+          },
+        },
+        'fr',
+        'tester',
+      );
+    });
+
+    it('should not delete unused keys', () => {
+      expect(deleteUnusedKeys).not.toHaveBeenCalled();
+    });
   });
 
-  it('should resolve', async () => {
-    await expect(runPhrase()).resolves.toBeUndefined();
+  describe('when deleteUnusedKeys is true', () => {
+    const config = { deleteUnusedKeys: true };
 
-    expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledTimes(2);
-  });
+    beforeEach(() => {
+      (pushTranslationsByLocale as jest.Mock).mockClear();
+      (writeFile as jest.Mock).mockClear();
+      (deleteUnusedKeys as jest.Mock).mockClear();
 
-  it('should update keys', async () => {
-    await expect(runPhrase()).resolves.toBeUndefined();
+      (pushTranslationsByLocale as jest.Mock).mockImplementation(() =>
+        Promise.resolve({ uploadId }),
+      );
+    });
 
-    expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
-      {
-        'hello.mytranslations': {
-          message: 'Hello',
-        },
-        'world.mytranslations': {
-          message: 'world',
-        },
-      },
-      'en',
-      'tester',
-    );
+    it('should resolve', async () => {
+      await expect(runPhrase(config)).resolves.toBeUndefined();
 
-    expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
-      {
-        'hello.mytranslations': {
-          message: 'Bonjour',
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledTimes(2);
+    });
+
+    it('should update keys', async () => {
+      await expect(runPhrase(config)).resolves.toBeUndefined();
+
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
+        {
+          'hello.mytranslations': {
+            message: 'Hello',
+          },
+          'world.mytranslations': {
+            message: 'world',
+          },
         },
-        'world.mytranslations': {
-          message: 'monde',
+        'en',
+        'tester',
+      );
+
+      expect(pushTranslationsByLocale as jest.Mock).toHaveBeenCalledWith(
+        {
+          'hello.mytranslations': {
+            message: 'Bonjour',
+          },
+          'world.mytranslations': {
+            message: 'monde',
+          },
         },
-      },
-      'fr',
-      'tester',
-    );
+        'fr',
+        'tester',
+      );
+    });
+
+    it('should delete unused keys', async () => {
+      await expect(runPhrase(config)).resolves.toBeUndefined();
+
+      expect(deleteUnusedKeys).toHaveBeenCalledWith(uploadId, 'en', 'tester');
+      expect(deleteUnusedKeys).toHaveBeenCalledWith(uploadId, 'fr', 'tester');
+    });
   });
 });


### PR DESCRIPTION
Adds a `deleteUnusedKeys` option to the `push` function in `@vocab/phrase`, and an equivalent `delete-unused-keys` flag to the `push` command in `@vocab/cli`. Setting the option/flag to true will delete all keys that weren't specified in the uploaded translations. Since we always upload all translations when pushing, this effectively deletes all unused keys from the Phrase project.

This functionality is [available in the Phrase UI](https://help.phrase.com/help/working-with-keys). This PR exposes it via the vocab phrase API and CLI.

API details:
- When [uploading](https://developers.phrase.com/api/#post-/projects/-project_id-/uploads) a file to Phrase, an `id` is returned
- When [deleting a collection of keys](https://developers.phrase.com/api/#delete-/projects/-project_id-/keys), the keys can be filtered by keys that were unmentioned in a given upload via the `unmentioned_in_upload` query parameter
- The natural progression of this is that we can get the upload id from the translation upload and use it to delete all keys that were unmentioned in that specific upload

Other notes:
- Fixed some typos
- Tweaked some of the logging so that some of the internal logs (e.g. headers, response length) are now using `trace` instead of `log` and some of the useful logs for users are using `log` instead of `trace`.