### PR TITLE
Rename fixture packages, create private `tests` and `test-helpers` packages

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,4 +9,5 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
+  "ignore": ["@fixtures/*", "@vocab-private/*"]
 }

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,4 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["fixture-direct", "fixture-simple", "fixture-server", "fixture-phrase"]
 }

--- a/fixtures/direct/package.json
+++ b/fixtures/direct/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-direct",
+  "name": "@fixtures/direct",
   "version": "1.0.1",
   "author": "SEEK",
   "private": true,

--- a/fixtures/phrase/package.json
+++ b/fixtures/phrase/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-phrase",
+  "name": "@fixtures/phrase",
   "description": "A playground reading and writing files for Phrase tests",
   "version": "1.0.0",
   "author": "SEEK",

--- a/fixtures/server/package.json
+++ b/fixtures/server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-server",
+  "name": "@fixtures/server",
   "version": "1.0.0",
   "author": "SEEK",
   "private": true,

--- a/fixtures/simple/package.json
+++ b/fixtures/simple/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fixture-simple",
+  "name": "@fixtures/simple",
   "version": "1.0.0",
   "author": "SEEK",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
     "url": "git+https://github.com/seek-oss/vocab.git"
   },
   "scripts": {
-    "start.direct": "yarn dev && manypkg run fixture-direct compile && yarn start-fixture fixture-direct",
-    "start.server": "yarn dev && manypkg run fixture-server compile && yarn start-fixture fixture-server",
-    "start.simple": "yarn dev && manypkg run fixture-simple compile && yarn start-fixture fixture-simple",
+    "start.direct": "yarn dev && manypkg run @fixtures/direct compile && yarn start-fixture direct",
+    "start.server": "yarn dev && manypkg run @fixtures/server compile && yarn start-fixture server",
+    "start.simple": "yarn dev && manypkg run @fixtures/simple compile && yarn start-fixture simple",
     "build": "preconstruct build",
     "dev": "preconstruct dev",
     "watch": "preconstruct watch",
-    "format": "yarn format.manypkg &&  yarn format.prettier",
+    "format": "yarn format.manypkg && yarn format.prettier",
     "format.manypkg": "manypkg fix",
     "format.prettier": "prettier --write .",
     "lint": "yarn lint.eslint && yarn lint.manypkg && yarn lint.prettier && yarn lint.tsc",
@@ -30,13 +30,14 @@
     "test": "jest",
     "test:local": "PUPPETEER_EXPERIMENTAL_CHROMIUM_MAC_ARM=1 jest",
     "copy-readme-to-packages": "ts-node scripts/copy-readme-to-packages",
-    "start-fixture": "ts-node tests/start-fixture",
-    "run-server-fixture": "ts-node tests/run-server-fixture",
-    "compile-fixtures": "manypkg run fixture-direct compile && manypkg run fixture-simple compile && manypkg run fixture-server compile"
+    "start-fixture": "ts-node test-helpers/src/start-fixture",
+    "run-server-fixture": "ts-node test-helpers/src/run-server-fixture",
+    "compile-fixtures": "manypkg run @fixtures/direct compile && manypkg run @fixtures/simple compile && manypkg run @fixtures/server compile"
   },
   "workspaces": [
     "packages/*",
-    "fixtures/*"
+    "fixtures/*",
+    "test-helpers"
   ],
   "preconstruct": {
     "packages": [

--- a/test-helpers/package.json
+++ b/test-helpers/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@vocab-private/test-helpers",
+  "private": true,
+  "version": "1.0.0",
+  "author": "SEEK",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "@fixtures/direct": "*",
+    "@fixtures/phrase": "*",
+    "@fixtures/server": "*",
+    "@fixtures/simple": "*",
+    "@types/wait-on": "^5.2.0",
+    "@types/webpack-dev-server": "^3.11.1",
+    "wait-on": "^5.2.0",
+    "webpack": "^5.11.0",
+    "webpack-dev-server": "^4.11.1"
+  }
+}

--- a/test-helpers/src/helpers.ts
+++ b/test-helpers/src/helpers.ts
@@ -18,16 +18,20 @@ export interface TestServer {
 
 let portCounter = 10001;
 
-export const runServerFixture = (fixtureName: string): Promise<TestServer> =>
+export type FixtureName = 'direct' | 'phrase' | 'server' | 'simple';
+
+export const runServerFixture = (
+  fixtureName: FixtureName,
+): Promise<TestServer> =>
   new Promise((resolve) => {
     const port = portCounter++;
-    const getConfig = require(`${fixtureName}/webpack.config.js`);
+    const getConfig = require(`@fixtures/${fixtureName}/webpack.config.js`);
     const config = getConfig();
     const compiler = webpack(config);
 
     compiler.hooks.done.tap('vocab-test-helper', async () => {
       const cwd = path.dirname(
-        require.resolve(`${fixtureName}/vocab.config.js`),
+        require.resolve(`@fixtures/${fixtureName}/vocab.config.js`),
       );
       const childProcess = spawn('node', ['./dist-server/server.js'], {
         env: { ...process.env, SERVER_PORT: port.toString() },
@@ -49,11 +53,11 @@ export const runServerFixture = (fixtureName: string): Promise<TestServer> =>
   });
 
 export const startFixture = (
-  fixtureName: string,
+  fixtureName: FixtureName,
   options: Options = {},
 ): Promise<TestServer> =>
   new Promise(async (resolve) => {
-    const getConfig = require(`${fixtureName}/webpack.config.js`);
+    const getConfig = require(`@fixtures/${fixtureName}/webpack.config.js`);
     const config = getConfig(options);
     const compiler = webpack(config);
 

--- a/test-helpers/src/index.ts
+++ b/test-helpers/src/index.ts
@@ -1,0 +1,1 @@
+export * from './helpers';

--- a/test-helpers/src/run-server-fixture.ts
+++ b/test-helpers/src/run-server-fixture.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
-import { runServerFixture } from './helpers';
+import { FixtureName, runServerFixture } from './helpers';
 
-const fixtureName = process.argv[2];
+const fixtureName = process.argv[2] as FixtureName;
 
 runServerFixture(fixtureName).then((server: any) => {
   // eslint-disable-next-line no-console

--- a/test-helpers/src/start-fixture.ts
+++ b/test-helpers/src/start-fixture.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env ts-node
-import { startFixture } from './helpers';
+import { FixtureName, startFixture } from './helpers';
 
-const fixtureName = process.argv[2];
+const fixtureName = process.argv[2] as FixtureName;
 
 startFixture(fixtureName).then((server) => {
   // eslint-disable-next-line no-console

--- a/tests/E2E.test.ts
+++ b/tests/E2E.test.ts
@@ -5,7 +5,7 @@ import {
   runServerFixture,
   TestServer,
   getLanguageChunk,
-} from './helpers';
+} from '@vocab-private/test-helpers';
 
 describe('E2E', () => {
   describe('Server with initial render', () => {
@@ -13,7 +13,7 @@ describe('E2E', () => {
 
     beforeAll(async () => {
       const config = resolveConfigSync(
-        require.resolve('fixture-server/vocab.config.js'),
+        require.resolve('@fixtures/server/vocab.config.js'),
       );
 
       if (!config) {
@@ -21,7 +21,7 @@ describe('E2E', () => {
       }
 
       await compile({}, config);
-      server = await runServerFixture('fixture-server');
+      server = await runServerFixture('server');
     });
 
     afterAll(() => {
@@ -52,7 +52,7 @@ describe('E2E', () => {
 
     beforeAll(async () => {
       const config = resolveConfigSync(
-        require.resolve('fixture-simple/vocab.config.js'),
+        require.resolve('@fixtures/simple/vocab.config.js'),
       );
 
       if (!config) {
@@ -60,7 +60,7 @@ describe('E2E', () => {
       }
 
       await compile({}, config);
-      server = await startFixture('fixture-simple');
+      server = await startFixture('simple');
     });
 
     beforeEach(async () => {
@@ -133,7 +133,7 @@ describe('E2E', () => {
 
     beforeAll(async () => {
       const config = resolveConfigSync(
-        require.resolve('fixture-simple/vocab.config.js'),
+        require.resolve('@fixtures/simple/vocab.config.js'),
       );
 
       if (!config) {
@@ -141,7 +141,7 @@ describe('E2E', () => {
       }
 
       await compile({}, config);
-      server = await startFixture('fixture-simple', {
+      server = await startFixture('simple', {
         disableVocabPlugin: true,
       });
     });
@@ -182,7 +182,7 @@ describe('E2E', () => {
 
     beforeAll(async () => {
       const config = resolveConfigSync(
-        require.resolve('fixture-direct/vocab.config.js'),
+        require.resolve('@fixtures/direct/vocab.config.js'),
       );
 
       if (!config) {
@@ -190,7 +190,7 @@ describe('E2E', () => {
       }
 
       await compile({}, config);
-      server = await startFixture('fixture-direct');
+      server = await startFixture('direct');
     });
 
     beforeEach(async () => {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vocab-private/tests",
+  "private": true,
+  "version": "1.0.0",
+  "author": "SEEK",
+  "license": "MIT",
+  "main": "src/index.ts",
+  "devDependencies": {
+    "@vocab-private": "*",
+    "@vocab/core": "^1.2.0"
+  }
+}


### PR DESCRIPTION
The pnpm changes are stacking up, splitting this stuff into a separate PR. Used the VE repo as reference for the tests and test helpers packages.

Also removed the `ignore` option from the changeset config as [it's only meant to be used temporarily.](https://github.com/changesets/changesets/blob/main/docs/config-file-options.md#ignore-array-of-packages)