### PR TITLE
Install `puppeteer` manually on cache miss

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,10 +28,15 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Cache Puppeteer
+        id: puppeteer-cache
         uses: actions/cache@v3
         with:
           path: /home/runner/.cache/puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
+
+      - name: Install Puppeteer
+        if: steps.puppeteer-cache.outputs.cache-hit != 'true'
+        run: node node_modules/puppeteer/install.js
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
Seems like merging version packages causes [a cache miss for the puppeteer cache step](https://github.com/seek-oss/vocab/actions/runs/4309075516/jobs/7516037632#step:10:15), so adding a conditional step that manually installs it if we get a cache miss.