### PR TITLE
Add changeset for `@vocab/types`

### DIFF
--- a/.changeset/strange-ants-compare.md
+++ b/.changeset/strange-ants-compare.md
@@ -1,0 +1,16 @@
+---
+'@vocab/types': minor
+---
+
+Add `StringWithSuggestions` utility type
+
+This type is equivalent to the `string` type, but it tricks the language server into prodiving
+suggestions for string literals passed into the `Suggestions` generic parameter.
+
+**EXAMPLE USAGE**:
+
+```ts
+type AnyAnimal = StringWithSuggestions<"cat" | "dog">;
+// Suggests cat and dog, but accepts any string
+const animal: AnyAnimal = "";
+```

--- a/.changeset/strange-ants-compare.md
+++ b/.changeset/strange-ants-compare.md
@@ -4,8 +4,7 @@
 
 Add `StringWithSuggestions` utility type
 
-This type is equivalent to the `string` type, but it tricks the language server into prodiving
-suggestions for string literals passed into the `Suggestions` generic parameter.
+This type is equivalent to the `string` type, but it tricks the language server into providing suggestions for string literals passed into the `Suggestions` generic parameter.
 
 **EXAMPLE USAGE**:
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,9 +17,9 @@ export type ICUFormatResult<T = unknown> = string | T | (string | T);
  * @example
  * Accept any string, but suggest specific animals
  * ```
- * type AnyAnimal = StringWithSuggestions<"cat" | "dog">
+ * type AnyAnimal = StringWithSuggestions<"cat" | "dog">;
  * // Suggests cat and dog, but accepts any string
- * const animal: AnyAnimal = ""
+ * const animal: AnyAnimal = "";
  * ```
  */
 export type StringWithSuggestions<Suggestions extends string> =


### PR DESCRIPTION
#119 should've had a changeset for `@vocab/types` 🤦. Without this release the fix in that PR won't actually work as it needs the new type.