### PR TITLE
Remaining Seconds as Relative Value

### DIFF
--- a/.changeset/chatty-penguins-brush.md
+++ b/.changeset/chatty-penguins-brush.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': patch
+---
+
+Display the remaining seconds in the rate limit relative to now.

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -22,15 +22,19 @@ function _callPhrase(path: string, options: Parameters<typeof fetch>[1] = {}) {
     },
   }).then(async (response) => {
     console.log(`${path}: ${response.status} - ${response.statusText}`);
+
+    const secondsUntilLimitReset = Math.ceil(
+      Number.parseFloat(response.headers.get('X-Rate-Limit-Reset') || '0') -
+        Date.now() / 1000,
+    );
     console.log(
       `Rate Limit: ${response.headers.get(
         'X-Rate-Limit-Remaining',
       )} of ${response.headers.get(
         'X-Rate-Limit-Limit',
-      )} remaining. (${response.headers.get(
-        'X-Rate-Limit-Reset',
-      )} seconds remaining})`,
+      )} remaining. (${secondsUntilLimitReset} seconds remaining})`,
     );
+
     trace('\nLink:', response.headers.get('Link'), '\n');
     // Print All Headers:
     // console.log(Array.from(r.headers.entries()));

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -32,7 +32,7 @@ function _callPhrase(path: string, options: Parameters<typeof fetch>[1] = {}) {
         'X-Rate-Limit-Remaining',
       )} of ${response.headers.get(
         'X-Rate-Limit-Limit',
-      )} remaining. (${secondsUntilLimitReset} seconds remaining})`,
+      )} remaining. (${secondsUntilLimitReset} seconds remaining)`,
     );
 
     trace('\nLink:', response.headers.get('Link'), '\n');


### PR DESCRIPTION
Display the remaining seconds as a relative number when pushing and pulling from the phrase API

Example Result:
<img width="786" alt="Example of successful push" src="https://user-images.githubusercontent.com/13903378/224875862-7ae3dc31-030c-4484-9641-87cda9bb3ce0.png">
