### PR TITLE
core: Fix incorrect self-referential parameter types

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,5 +9,8 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["@fixtures/*", "@vocab-private/*"]
+  "ignore": ["@fixtures/*", "@vocab-private/*"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "updateInternalDependents": "always"
+  }
 }

--- a/.changeset/kind-eels-enjoy.md
+++ b/.changeset/kind-eels-enjoy.md
@@ -1,0 +1,40 @@
+---
+'@vocab/core': patch
+---
+
+Fix compiled type for self-referential parameters
+
+`plural`, `select` and `selectOrdinal` parameters can reference themselves in their own match clauses.
+In most cases it's recommended to use the special `#` token to reference the input parameter.
+Using the `#` token can enhanced readability in long messages, and it makes renaming a parameter much quicker, since you only need to change the parameter name in one place.
+
+For example:
+
+```jsonc
+{
+  "I have numCats cats": {
+    "message": "I have {numCats, plural, 1 {# cat} other {# cats}}"
+  }
+}
+```
+
+You can however use the parameter name directly if you want to:
+
+```jsonc
+{
+  "I have numCats cats": {
+    // This message is equivalent to the message in the previous example
+    "message": "I have {numCats, plural, 1 {{numCats} cat} other {{numCats} cats}}"
+  }
+}
+```
+
+In the above example, a bug in Vocab caused an incorrect type to be assigned to this parameter:
+
+```ts
+// Type Error: Type 'number' is not assignable to type 'string'
+// `numCats` should be of type `number`, but is instead of type `string`
+t('I have numCats cats', { numCats: 3 });
+```
+
+Vocab now generates the correct type in this case.

--- a/.changeset/kind-eels-enjoy.md
+++ b/.changeset/kind-eels-enjoy.md
@@ -5,8 +5,8 @@
 Fix compiled type for self-referential parameters
 
 `plural`, `select` and `selectOrdinal` parameters can reference themselves in their own match clauses.
-In most cases it's recommended to use the special `#` token to reference the input parameter.
-Using the `#` token can enhanced readability in long messages, and it makes renaming a parameter much quicker, since you only need to change the parameter name in one place.
+In most cases, it's recommended to use the special `#` token to reference the input parameter.
+Using the `#` token can enhance readability in long messages, and it makes renaming a parameter much quicker, since you only need to change the parameter name in one place.
 
 For example:
 

--- a/.changeset/kind-eels-enjoy.md
+++ b/.changeset/kind-eels-enjoy.md
@@ -29,7 +29,7 @@ You can however use the parameter name directly if you want to:
 }
 ```
 
-In the above example, a bug in Vocab caused an incorrect type to be assigned to this parameter:
+In the above example, a bug in Vocab caused an incorrect type to be assigned to the `numCats` parameter:
 
 ```ts
 // Type Error: Type 'number' is not assignable to type 'string'

--- a/.changeset/kind-eels-enjoy.md
+++ b/.changeset/kind-eels-enjoy.md
@@ -13,7 +13,7 @@ For example:
 ```jsonc
 {
   "I have numCats cats": {
-    "message": "I have {numCats, plural, 1 {# cat} other {# cats}}"
+    "message": "I have {numCats, plural, one {# cat} other {# cats}}"
   }
 }
 ```
@@ -24,7 +24,7 @@ You can however use the parameter name directly if you want to:
 {
   "I have numCats cats": {
     // This message is equivalent to the message in the previous example
-    "message": "I have {numCats, plural, 1 {{numCats} cat} other {{numCats} cats}}"
+    "message": "I have {numCats, plural, one {{numCats} cat} other {{numCats} cats}}"
   }
 }
 ```

--- a/fixtures/all-message-types/src/.vocab/translations.json
+++ b/fixtures/all-message-types/src/.vocab/translations.json
@@ -23,16 +23,28 @@
   "Select": {
     "message": "{foo, select, a {a} b {b} other {c}}"
   },
-  "Plural": {
-    "message": "{itemCount, plural, one {# item} other {# items}}"
-  },
   "Select ordinal": {
     "message": "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!"
+  },
+  "Select ordinal with self-referential param": {
+    "message": "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!"
+  },
+  "Plural": {
+    "message": "{itemCount, plural, one {# item} other {# items}}"
   },
   "Plural with nested params": {
     "message": "{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}"
   },
+  "Plural with self-referential param": {
+    "message": "{foo, plural, 0 {a} 1 {b} other {{foo} c}}"
+  },
   "Select with nested params": {
     "message": "{foo, select, a {{bar} a} b {{baz} b} other {c}}"
+  },
+  "Select with pound element": {
+    "message": "{foo, select, a {# a} b {# b} other {c}}"
+  },
+  "Select with self-referential param": {
+    "message": "{foo, select, 0 {a} 1 {b} other {{foo} c}}"
   }
 }

--- a/fixtures/all-message-types/src/.vocab/translations.json
+++ b/fixtures/all-message-types/src/.vocab/translations.json
@@ -29,14 +29,14 @@
   "Plural with self-referential param": {
     "message": "{foo, plural, zero {a} one {b} other {{foo} c}}"
   },
-  "Select": {
-    "message": "{foo, select, a {a} b {b} other {c}}"
-  },
   "Select ordinal": {
     "message": "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!"
   },
   "Select ordinal with self-referential param": {
     "message": "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!"
+  },
+  "Select": {
+    "message": "{foo, select, a {a} b {b} other {c}}"
   },
   "Select with nested params": {
     "message": "{foo, select, a {{bar} a} b {{baz} b} other {c}}"

--- a/fixtures/all-message-types/src/.vocab/translations.json
+++ b/fixtures/all-message-types/src/.vocab/translations.json
@@ -20,15 +20,6 @@
   "Nested tags": {
     "message": "The quick <Bold>brown <Italic>fox</Italic></Bold>"
   },
-  "Select": {
-    "message": "{foo, select, a {a} b {b} other {c}}"
-  },
-  "Select ordinal": {
-    "message": "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!"
-  },
-  "Select ordinal with self-referential param": {
-    "message": "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!"
-  },
   "Plural": {
     "message": "{itemCount, plural, one {# item} other {# items}}"
   },
@@ -37,6 +28,15 @@
   },
   "Plural with self-referential param": {
     "message": "{foo, plural, zero {a} one {b} other {{foo} c}}"
+  },
+  "Select": {
+    "message": "{foo, select, a {a} b {b} other {c}}"
+  },
+  "Select ordinal": {
+    "message": "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!"
+  },
+  "Select ordinal with self-referential param": {
+    "message": "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!"
   },
   "Select with nested params": {
     "message": "{foo, select, a {{bar} a} b {{baz} b} other {c}}"

--- a/fixtures/all-message-types/src/.vocab/translations.json
+++ b/fixtures/all-message-types/src/.vocab/translations.json
@@ -36,7 +36,7 @@
     "message": "{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}"
   },
   "Plural with self-referential param": {
-    "message": "{foo, plural, 0 {a} 1 {b} other {{foo} c}}"
+    "message": "{foo, plural, zero {a} one {b} other {{foo} c}}"
   },
   "Select with nested params": {
     "message": "{foo, select, a {{bar} a} b {{baz} b} other {c}}"
@@ -45,6 +45,6 @@
     "message": "{foo, select, a {# a} b {# b} other {c}}"
   },
   "Select with self-referential param": {
-    "message": "{foo, select, 0 {a} 1 {b} other {{foo} c}}"
+    "message": "{foo, select, a {a} b {b} other {{foo} c}}"
   }
 }

--- a/tests/__snapshots__/translation-types.test.ts.snap
+++ b/tests/__snapshots__/translation-types.test.ts.snap
@@ -43,7 +43,7 @@ const translations = createTranslationFile<
       foo: StringWithSuggestions<'a' | 'b'>;
     }) => string;
     'Select with self-referential param': (values: {
-      foo: StringWithSuggestions<'0' | '1'>;
+      foo: StringWithSuggestions<'a' | 'b'>;
     }) => string;
   }
 >({
@@ -64,12 +64,12 @@ const translations = createTranslationFile<
     'Plural with nested params':
       '{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}',
     'Plural with self-referential param':
-      '{foo, plural, 0 {a} 1 {b} other {{foo} c}}',
+      '{foo, plural, zero {a} one {b} other {{foo} c}}',
     'Select with nested params':
       '{foo, select, a {{bar} a} b {{baz} b} other {c}}',
     'Select with pound element': '{foo, select, a {# a} b {# b} other {c}}',
     'Select with self-referential param':
-      '{foo, select, 0 {a} 1 {b} other {{foo} c}}',
+      '{foo, select, a {a} b {b} other {{foo} c}}',
   }),
 });
 

--- a/tests/__snapshots__/translation-types.test.ts.snap
+++ b/tests/__snapshots__/translation-types.test.ts.snap
@@ -23,17 +23,27 @@ const translations = createTranslationFile<
       Italic: FormatXMLElementFn<T>;
     }) => string | T | Array<string | T>;
     Select: (values: { foo: StringWithSuggestions<'a' | 'b'> }) => string;
-    Plural: (values: { itemCount: number }) => string;
     'Select ordinal': (values: { year: number }) => string;
+    'Select ordinal with self-referential param': (values: {
+      year: number;
+    }) => string;
+    Plural: (values: { itemCount: number }) => string;
     'Plural with nested params': (values: {
       numDogs: number;
       singularPrefix: string;
       pluralPrefix: string;
     }) => string;
+    'Plural with self-referential param': (values: { foo: number }) => string;
     'Select with nested params': (values: {
       foo: StringWithSuggestions<'a' | 'b'>;
       bar: string;
       baz: string;
+    }) => string;
+    'Select with pound element': (values: {
+      foo: StringWithSuggestions<'a' | 'b'>;
+    }) => string;
+    'Select with self-referential param': (values: {
+      foo: StringWithSuggestions<'0' | '1'>;
     }) => string;
   }
 >({
@@ -46,13 +56,20 @@ const translations = createTranslationFile<
     Time: 'Coupon expires at {expires, time, short}',
     'Nested tags': 'The quick <Bold>brown <Italic>fox</Italic></Bold>',
     Select: '{foo, select, a {a} b {b} other {c}}',
-    Plural: '{itemCount, plural, one {# item} other {# items}}',
     'Select ordinal':
       "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!",
+    'Select ordinal with self-referential param':
+      "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!",
+    Plural: '{itemCount, plural, one {# item} other {# items}}',
     'Plural with nested params':
       '{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}',
+    'Plural with self-referential param':
+      '{foo, plural, 0 {a} 1 {b} other {{foo} c}}',
     'Select with nested params':
       '{foo, select, a {{bar} a} b {{baz} b} other {c}}',
+    'Select with pound element': '{foo, select, a {# a} b {# b} other {c}}',
+    'Select with self-referential param':
+      '{foo, select, 0 {a} 1 {b} other {{foo} c}}',
   }),
 });
 

--- a/tests/__snapshots__/translation-types.test.ts.snap
+++ b/tests/__snapshots__/translation-types.test.ts.snap
@@ -22,11 +22,6 @@ const translations = createTranslationFile<
       Bold: FormatXMLElementFn<T>;
       Italic: FormatXMLElementFn<T>;
     }) => string | T | Array<string | T>;
-    Select: (values: { foo: StringWithSuggestions<'a' | 'b'> }) => string;
-    'Select ordinal': (values: { year: number }) => string;
-    'Select ordinal with self-referential param': (values: {
-      year: number;
-    }) => string;
     Plural: (values: { itemCount: number }) => string;
     'Plural with nested params': (values: {
       numDogs: number;
@@ -34,6 +29,11 @@ const translations = createTranslationFile<
       pluralPrefix: string;
     }) => string;
     'Plural with self-referential param': (values: { foo: number }) => string;
+    'Select ordinal': (values: { year: number }) => string;
+    'Select ordinal with self-referential param': (values: {
+      year: number;
+    }) => string;
+    Select: (values: { foo: StringWithSuggestions<'a' | 'b'> }) => string;
     'Select with nested params': (values: {
       foo: StringWithSuggestions<'a' | 'b'>;
       bar: string;
@@ -55,16 +55,16 @@ const translations = createTranslationFile<
     Date: 'Sale begins {start, date, medium}',
     Time: 'Coupon expires at {expires, time, short}',
     'Nested tags': 'The quick <Bold>brown <Italic>fox</Italic></Bold>',
-    Select: '{foo, select, a {a} b {b} other {c}}',
-    'Select ordinal':
-      "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!",
-    'Select ordinal with self-referential param':
-      "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!",
     Plural: '{itemCount, plural, one {# item} other {# items}}',
     'Plural with nested params':
       '{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}',
     'Plural with self-referential param':
       '{foo, plural, zero {a} one {b} other {{foo} c}}',
+    'Select ordinal':
+      "It's my cat's {year, selectordinal, one {#st} two {#nd} few {#rd} other {#th}} birthday!",
+    'Select ordinal with self-referential param':
+      "It's my cat's {year, selectordinal, one {{year}st} two {{year}nd} few {{year}rd} other {{year}th}} birthday!",
+    Select: '{foo, select, a {a} b {b} other {c}}',
     'Select with nested params':
       '{foo, select, a {{bar} a} b {{baz} b} other {c}}',
     'Select with pound element': '{foo, select, a {# a} b {# b} other {c}}',


### PR DESCRIPTION
See changeset.

## Implementation details
By keeping track of parameters we've already assigned types to, we can ensure we don't overwrite types if they're parsed again

## Other

Also set `updateInternalDependents: "always"` in the changeset config as this behaviour is useful for vocab in particular as updates to `@vocab/core` should propagate updates to its dependents. Changing this setting will result in a few packages being published in order to catch them up to the latest versions of their vocab deps.