### PR TITLE
Use correct cache path for Puppeteer on Windows

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -76,7 +76,7 @@ jobs:
         id: puppeteer-cache
         uses: actions/cache@v3
         with:
-          path: /home/runner/.cache/puppeteer
+          path: C:\Users\runneradmin\.cache\puppeteer
           key: puppeteer-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
 
       - name: Install Puppeteer


### PR DESCRIPTION
Puppeteer wasn't cached on Windows 😅 https://github.com/seek-oss/vocab/actions/runs/4759996202/jobs/8459839277#step:17:2

Now it is: https://github.com/seek-oss/vocab/actions/runs/4760153463/jobs/8460236237#step:17:4