### PR TITLE
Webpack loader: Handle ESM and CJS modules

### DIFF
--- a/.changeset/little-pants-fold.md
+++ b/.changeset/little-pants-fold.md
@@ -2,4 +2,4 @@
 '@vocab/webpack': patch
 ---
 
-Resolve exports for CJS
+Generate virtual module code in the same format (ESM or CJS) as the translation file

--- a/.changeset/little-pants-fold.md
+++ b/.changeset/little-pants-fold.md
@@ -1,0 +1,5 @@
+---
+'@vocab/webpack': patch
+---
+
+Resolve exports for CJS

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "@vocab/core": "^1.3.0",
     "chalk": "^4.1.0",
+    "cjs-module-lexer": "^1.2.2",
     "debug": "^4.3.1",
     "es-module-lexer": "^0.9.3",
     "virtual-resource-loader": "^1.0.1"

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -90,8 +90,6 @@ export default async function vocabLoader(this: LoaderContext, source: string) {
     throw new Error(`Webpack didn't provide an async callback`);
   }
 
-  // this is necessary for the Web Assembly boot
-  await esModuleLexer.init;
 
   const config = this.getOptions();
 
@@ -124,6 +122,8 @@ export default async function vocabLoader(this: LoaderContext, source: string) {
   `;
   let result;
 
+  // this is necessary for the Web Assembly boot
+  await esModuleLexer.init;
   const esmExports = findExportNames(source, 'esm');
   if (esmExports.length > 0) {
     const exportName = esmExports[0];

--- a/packages/webpack/src/loader.ts
+++ b/packages/webpack/src/loader.ts
@@ -90,7 +90,6 @@ export default async function vocabLoader(this: LoaderContext, source: string) {
     throw new Error(`Webpack didn't provide an async callback`);
   }
 
-
   const config = this.getOptions();
 
   const devJsonFilePath = getDevLanguageFileFromTsFile(this.resourcePath);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -313,6 +313,7 @@ importers:
       '@types/debug': ^4.1.5
       '@vocab/core': link:../core
       chalk: ^4.1.0
+      cjs-module-lexer: ^1.2.2
       debug: ^4.3.1
       es-module-lexer: ^0.9.3
       virtual-resource-loader: ^1.0.1
@@ -320,6 +321,7 @@ importers:
     dependencies:
       '@vocab/core': link:../core
       chalk: 4.1.2
+      cjs-module-lexer: 1.2.2
       debug: 4.3.4
       es-module-lexer: 0.9.3
       virtual-resource-loader: link:../virtual-resource-loader
@@ -3572,7 +3574,7 @@ packages:
       '@babel/core': 7.21.0
       find-cache-dir: 3.3.2
       schema-utils: 4.0.0
-      webpack: 5.76.3_webpack-cli@5.0.1
+      webpack: 5.76.3
     dev: false
 
   /babel-plugin-istanbul/6.1.1:
@@ -8470,7 +8472,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       terser: 5.16.5
-      webpack: 5.76.3_webpack-cli@5.0.1
+      webpack: 5.76.3
 
   /terser/5.16.5:
     resolution: {integrity: sha512-qcwfg4+RZa3YvlFh0qjifnzBHjKGNbtDo9yivMqMFDy9Q6FSaQWSB/j1xKhsoUFJIqDOM3TsN6D5xbrMrFcHbg==}


### PR DESCRIPTION
Before this change, the webpack loader generated ESM code for the virtual module because the source was a TypeScript file (`*.vocab/index.ts`).

Since [@vocab/webpack@1.2.0](https://github.com/seek-oss/vocab/releases/tag/%40vocab%2Fwebpack%401.2.0), the format of the generated code must match the source code, and that is what this PR aims to achieve.

Encountered while testing in https://github.com/seek-oss/crackle/pull/104