### PR TITLE
Fix generated types when a tag is inside a plural argument

### DIFF
--- a/.changeset/curvy-points-argue.md
+++ b/.changeset/curvy-points-argue.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+Fix generated types when a tag is inside a plural argument

--- a/fixtures/translation-types/src/all-message-types/.vocab/translations.json
+++ b/fixtures/translation-types/src/all-message-types/.vocab/translations.json
@@ -26,6 +26,9 @@
   "Plural with nested params": {
     "message": "{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}"
   },
+  "Plural with nested tag": {
+    "message": "{numDogs, plural, one {<Bold>#</Bold> dog} other {<Bold>#</Bold> dogs}}"
+  },
   "Plural with self-referential param": {
     "message": "{foo, plural, zero {a} one {b} other {{foo} c}}"
   },
@@ -43,6 +46,9 @@
   },
   "Select with pound element": {
     "message": "{foo, select, a {# a} b {# b} other {c}}"
+  },
+  "Select with nested tag": {
+    "message": "{foo, select, a {<Bold>a</Bold>} other {<Bold>other</Bold>}}"
   },
   "Select with self-referential param": {
     "message": "{foo, select, a {a} b {b} other {{foo} c}}"

--- a/packages/core/src/compile.ts
+++ b/packages/core/src/compile.ts
@@ -41,10 +41,11 @@ interface TranslationTypeInfo {
 
 function extractHasTags(ast: MessageFormatElement[]): boolean {
   return ast.some((element) => {
-    if (isSelectElement(element)) {
+    if (isSelectElement(element) || isPluralElement(element)) {
       const children = Object.values(element.options).map((o) => o.value);
       return children.some((child) => extractHasTags(child));
     }
+
     return isTagElement(element);
   });
 }

--- a/tests/__snapshots__/translation-types.test.ts.snap
+++ b/tests/__snapshots__/translation-types.test.ts.snap
@@ -42,6 +42,10 @@ const translations = createTranslationFile<
       singularPrefix: string;
       pluralPrefix: string;
     }) => string;
+    'Plural with nested tag': <T = string>(values: {
+      numDogs: number;
+      Bold: FormatXMLElementFn<T>;
+    }) => ReturnType<FormatXMLElementFn<T>>;
     'Plural with self-referential param': (values: { foo: number }) => string;
     'Select ordinal': (values: { year: number }) => string;
     'Select ordinal with self-referential param': (values: {
@@ -56,6 +60,10 @@ const translations = createTranslationFile<
     'Select with pound element': (values: {
       foo: StringWithSuggestions<'a' | 'b'>;
     }) => string;
+    'Select with nested tag': <T = string>(values: {
+      foo: StringWithSuggestions<'a'>;
+      Bold: FormatXMLElementFn<T>;
+    }) => ReturnType<FormatXMLElementFn<T>>;
     'Select with self-referential param': (values: {
       foo: StringWithSuggestions<'a' | 'b'>;
     }) => string;
@@ -72,6 +80,8 @@ const translations = createTranslationFile<
     Plural: '{itemCount, plural, one {# item} other {# items}}',
     'Plural with nested params':
       '{numDogs, plural, one {# {singularPrefix} dog} other {# {pluralPrefix} dogs}}',
+    'Plural with nested tag':
+      '{numDogs, plural, one {<Bold>#</Bold> dog} other {<Bold>#</Bold> dogs}}',
     'Plural with self-referential param':
       '{foo, plural, zero {a} one {b} other {{foo} c}}',
     'Select ordinal':
@@ -82,6 +92,8 @@ const translations = createTranslationFile<
     'Select with nested params':
       '{foo, select, a {{bar} a} b {{baz} b} other {c}}',
     'Select with pound element': '{foo, select, a {# a} b {# b} other {c}}',
+    'Select with nested tag':
+      '{foo, select, a {<Bold>a</Bold>} other {<Bold>other</Bold>}}',
     'Select with self-referential param':
       '{foo, select, a {a} b {b} other {{foo} c}}',
   }),


### PR DESCRIPTION
Currently, messages with select arguments that contain a tag will have correct types generated, but those with plural arguments that contain a tag will not.

E.g.


```
{foo, select, a {<Bold>a</Bold>} other {<Bold>other</Bold>}}
```

Generates:

```ts
// This is correct
<T = string>(values: {
  foo: StringWithSuggestions<'a'>;
  Bold: FormatXMLElementFn<T>;
}) => ReturnType<FormatXMLElementFn<T>>
```

But
```
{numDogs, plural, one {<Bold>#</Bold> dog} other {<Bold>#</Bold> dogs}}
```

Generates:
```ts
// This is wrong
(values: {
  numDogs: number;
  Bold: string;
}) => string
```

This PR fixes type generation so it also handles these kinds of plural rules correctly.