### PR TITLE
phrase: Update descriptions when pushing translations

### DIFF
--- a/.changeset/rotten-items-eat.md
+++ b/.changeset/rotten-items-eat.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': patch
+---
+
+Update descriptions when pushing translations

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -134,6 +134,7 @@ export async function pushTranslations(
   formData.append('file_format', 'csv');
   formData.append('branch', branch);
   formData.append('update_translations', 'true');
+  formData.append('update_descriptions', 'true');
 
   for (const [locale, index] of Object.entries(localeMapping)) {
     formData.append(`locale_mapping[${locale}]`, index);

--- a/tests/E2E.test.ts
+++ b/tests/E2E.test.ts
@@ -6,9 +6,6 @@ import {
   getLanguageChunk,
 } from '@vocab-private/test-helpers';
 
-// Puppeteer methods can sometimes take a bit longer on CI (especially on windows)
-page.setDefaultTimeout(2000);
-
 describe('E2E', () => {
   describe('Server with initial render', () => {
     let server: TestServer;

--- a/tests/E2E.test.ts
+++ b/tests/E2E.test.ts
@@ -77,7 +77,7 @@ describe('E2E', () => {
 
       const message = await page.waitForSelector('#message');
 
-      await expect(message).toMatch('[Ḩẽẽƚƚöö] [ŵöööřƚƌ]');
+      await expect(message).toMatch('[Ḩẽẽƚƚöö] [ŵöööřƚƌ]', { timeout: 2000 });
     });
 
     it('should allow special characters', async () => {


### PR DESCRIPTION
Unsure if this was previous behaviour that broke when we moved to uploading all translations in a single CSV (#101), it was never supported in the first place, or Phrase changed the default.

Note that the dev language descriptions are used for messages in all languages. Changing a description on a non-dev language message will have no effect, and will be overwritten when translations are pulled.