### PR TITLE
phrase: Upload translations in a separate file per language

### DIFF
--- a/.changeset/spicy-eggs-divide.md
+++ b/.changeset/spicy-eggs-divide.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': patch
+---
+
+Upload translations in a separate file per language

--- a/.changeset/spicy-eggs-divide.md
+++ b/.changeset/spicy-eggs-divide.md
@@ -3,3 +3,11 @@
 ---
 
 Upload translations in a separate file per language
+
+Fixes a regression introduced when [support for Phrase tags was added][phrase tags pr].
+Part of adding support for tags involved swapping to uploading translations in a CSV file instead of a JSON file.
+This had the unintended (and undocumented) side-effect of creating missing languages in the target Phrase project.
+This is unnecessary in the case where the language doesn't actually have any translations and/or derives its translations from a parent language.
+Only languages that actually have translations (i.e. they have messages defined in a `translations.json` file) will be created in the target Phrase project.
+
+[phrase tags pr]: https://github.com/seek-oss/vocab/pull/101

--- a/packages/phrase/src/csv.test.ts
+++ b/packages/phrase/src/csv.test.ts
@@ -35,27 +35,29 @@ describe('translationsToCsv', () => {
           description: 'Hello in English',
         },
       },
+      th: {},
     };
 
-    const { csvString, localeMapping, keyIndex, commentIndex, tagColumn } =
+    const { csvFileStrings, keyIndex, commentIndex, tagColumn, messageIndex } =
       translationsToCsv(translations, devLanguage);
 
-    expect(csvString).toMatchInlineSnapshot(`
-      "Hello,Bonjour,Hello,,"greeting,hello,word"
-      World,Monde,World,Some description,
-      Hello,Au revoir,Goodbye,,"greeting,hello,word"
-      Foo,,Foo,,
-      "
-    `);
-
-    expect(localeMapping).toMatchInlineSnapshot(`
+    expect(csvFileStrings).toMatchInlineSnapshot(`
       {
-        "en": 1,
-        "fr": 2,
+        "en": "Hello,,"greeting,hello,word",Hello
+      World,Some description,,World
+      Goodbye,,"greeting,hello,word",Hello
+      Foo,,,Foo
+      ",
+        "fr": "Hello,,"greeting,hello,word",Bonjour
+      World,Some description,,Monde
+      Goodbye,,"greeting,hello,word",Au revoir
+      ",
       }
     `);
-    expect(keyIndex).toEqual(3);
-    expect(commentIndex).toEqual(4);
-    expect(tagColumn).toEqual(5);
+
+    expect(keyIndex).toEqual(1);
+    expect(commentIndex).toEqual(2);
+    expect(tagColumn).toEqual(3);
+    expect(messageIndex).toEqual(4);
   });
 });

--- a/packages/phrase/src/push-translations.test.ts
+++ b/packages/phrase/src/push-translations.test.ts
@@ -14,7 +14,7 @@ jest.mock('./phrase-api', () => ({
   deleteUnusedKeys: jest.fn(() => Promise.resolve()),
 }));
 
-const uploadId = '1234';
+const devLanguageUploadId = '1234';
 
 function runPhrase(config: { deleteUnusedKeys: boolean }) {
   return push(
@@ -47,7 +47,7 @@ describe('push', () => {
 
       jest
         .mocked(pushTranslations)
-        .mockImplementation(() => Promise.resolve({ uploadId }));
+        .mockImplementation(() => Promise.resolve({ devLanguageUploadId }));
     });
 
     it('should resolve', async () => {
@@ -118,7 +118,7 @@ describe('push', () => {
       beforeEach(() => {
         jest
           .mocked(pushTranslations)
-          .mockImplementation(() => Promise.resolve({ uploadId }));
+          .mockImplementation(() => Promise.resolve({ devLanguageUploadId }));
       });
 
       it('should resolve', async () => {
@@ -174,7 +174,10 @@ describe('push', () => {
       it('should delete unused keys', async () => {
         await expect(runPhrase(config)).resolves.toBeUndefined();
 
-        expect(deleteUnusedKeys).toHaveBeenCalledWith(uploadId, 'tester');
+        expect(deleteUnusedKeys).toHaveBeenCalledWith(
+          devLanguageUploadId,
+          'tester',
+        );
       });
     });
 

--- a/packages/phrase/src/push-translations.ts
+++ b/packages/phrase/src/push-translations.ts
@@ -66,12 +66,12 @@ export async function push(
     }
   }
 
-  const { uploadId } = await pushTranslations(phraseTranslations, {
+  const { devLanguageUploadId } = await pushTranslations(phraseTranslations, {
     devLanguage: config.devLanguage,
     branch,
   });
 
   if (deleteUnusedKeys) {
-    await phraseDeleteUnusedKeys(uploadId, branch);
+    await phraseDeleteUnusedKeys(devLanguageUploadId, branch);
   }
 }


### PR DESCRIPTION
Fixes a regression introduced by #101.

Part of adding support for Phrase tags required us to upload translations in a CSV file rather than a JSON file (as [the JSON file format we were using](https://support.phrase.com/hc/en-us/articles/6111346248860--JSON-Simple-Strings-) did not support tags). CSV files allow you to specify messages for multiple languages in one file, so in addition to adding support for tags, we changed the `push` API to just upload all translations in a single file, rather than separate JSON files per locale. 

Unfortunately, Phrase treats CSV file uploads differently to JSON file uploads, creating any missing languages in your phrase project, rather than failing the upload for unconfigured languages. This behaviour is not documented in either [the CSV file type docs](https://support.phrase.com/hc/en-us/articles/6111361680540--CSV-Strings-/) or [the `uploads` API docs](https://developers.phrase.com/api/#post-/projects/-project_id-/uploads).

This had the unintended side-effect of creating languages for every configured vocab language, even if those languages didn't contain any explicit translations (i.e. the translations messages would fall back to another language or the dev language). This means that a project with 100 translation keys and 5 languages would end up with 500 total messages in Phrase, even if the app hadn't been translated yet.

This PR fixes the behaviour to _sort of_ behave like it did before. Translations are now uploaded in a single file per language, as was the case before #101, however we're keeping the CSV format in order to maintain support for Phrase tags. A translation file will not be uploaded for languages that do not contain any translations, so as to avoid unnecessarily adding new languages to the Phrase project.



