### PR TITLE
Vocab pull use translation of custom key

### DIFF
--- a/.changeset/nasty-seahorses-confess.md
+++ b/.changeset/nasty-seahorses-confess.md
@@ -1,0 +1,15 @@
+---
+'@vocab/phrase': minor
+'@vocab/core': minor
+---
+
+Vocab pull: support custom key
+
+```json
+{
+  "thanks": {
+    "message": "Thanks",
+    "global-key": "app.thanks.label"
+  }
+}
+```

--- a/fixtures/phrase/src/mytranslations.vocab/translations.json
+++ b/fixtures/phrase/src/mytranslations.vocab/translations.json
@@ -8,5 +8,9 @@
   },
   "world": {
     "message": "world"
+  },
+  "thanks": {
+    "message": "Thanks",
+    "global-key": "app.thanks.label"
   }
 }

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -202,3 +202,5 @@ export function resolveConfigSync(
 
   return null;
 }
+
+export const GLOBAL_KEY = 'global-key';

--- a/packages/core/src/load-translations.ts
+++ b/packages/core/src/load-translations.ts
@@ -411,8 +411,7 @@ export async function loadAllTranslations(
         );
       }
       keys.add(uniqueKey);
-    }
-    for (const key of loadedTranslation.keys) {
+
       const globalKey =
         loadedTranslation.languages[config.devLanguage][key][GLOBAL_KEY];
       if (globalKey) {

--- a/packages/core/src/load-translations.ts
+++ b/packages/core/src/load-translations.ts
@@ -21,6 +21,7 @@ import {
   getDevTranslationFileGlob,
 } from './utils';
 import { generateLanguageFromTranslations } from './generate-language';
+import { GLOBAL_KEY } from './config';
 
 export function getUniqueKey(key: string, namespace: string) {
   return `${key}.${namespace}`;
@@ -410,6 +411,18 @@ export async function loadAllTranslations(
         );
       }
       keys.add(uniqueKey);
+    }
+    for (const key of loadedTranslation.keys) {
+      const globalKey =
+        loadedTranslation.languages[config.devLanguage][key][GLOBAL_KEY];
+      if (globalKey) {
+        if (keys.has(globalKey)) {
+          throw new Error(
+            `Duplicate keys found. Global key ${key} was found multiple times`,
+          );
+        }
+        keys.add(globalKey);
+      }
     }
   }
   return result;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,6 +137,7 @@ export interface TranslationData {
   message: TranslationMessage;
   description?: string;
   tags?: Tags;
+  "global-key"?: string;
 }
 
 export type TranslationsByKey<Key extends TranslationKey = string> = Record<

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -137,7 +137,7 @@ export interface TranslationData {
   message: TranslationMessage;
   description?: string;
   tags?: Tags;
-  "global-key"?: string;
+  'global-key'?: string;
 }
 
 export type TranslationsByKey<Key extends TranslationKey = string> = Record<

--- a/packages/phrase/src/config.ts
+++ b/packages/phrase/src/config.ts
@@ -1,0 +1,1 @@
+export const GLOBAL_KEY = 'global-key';

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -41,10 +41,16 @@ describe('pull translations', () => {
             'hello.mytranslations': {
               message: 'Hi there',
             },
+            'app.thanks.label': {
+              message: 'Thank you.',
+            },
           },
           fr: {
             'hello.mytranslations': {
               message: 'merci',
+            },
+            'app.thanks.label': {
+              message: 'Merci.',
             },
           },
         }),
@@ -98,6 +104,10 @@ describe('pull translations', () => {
                 "greeting",
               ],
             },
+            "thanks": {
+              "global-key": "app.thanks.label",
+              "message": "Thank you.",
+            },
             "world": {
               "message": "world",
             },
@@ -105,6 +115,9 @@ describe('pull translations', () => {
           {
             "hello": {
               "message": "merci",
+            },
+            "thanks": {
+              "message": "Merci.",
             },
             "world": {
               "message": "monde",
@@ -181,6 +194,10 @@ describe('pull translations', () => {
                 "only for this key",
                 "greeting",
               ],
+            },
+            "thanks": {
+              "global-key": "app.thanks.label",
+              "message": "Thanks",
             },
             "world": {
               "message": "world",

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -11,6 +11,7 @@ import type { TranslationFileContents, UserConfig } from '@vocab/core';
 
 import { pullAllTranslations, ensureBranch } from './phrase-api';
 import { trace } from './logger';
+import { GLOBAL_KEY } from './config';
 
 interface PullOptions {
   branch?: string;
@@ -61,7 +62,8 @@ export async function pull(
       defaultValues[key] = {
         ...defaultValues[key],
         ...allPhraseTranslations[config.devLanguage][
-          getUniqueKey(key, loadedTranslation.namespace)
+          defaultValues[key][GLOBAL_KEY] ??
+            getUniqueKey(key, loadedTranslation.namespace)
         ],
       };
     }
@@ -85,7 +87,9 @@ export async function pull(
           allPhraseTranslations[alternativeLanguage];
 
         for (const key of localKeys) {
-          const phraseKey = getUniqueKey(key, loadedTranslation.namespace);
+          const phraseKey =
+            defaultValues[key][GLOBAL_KEY] ??
+            getUniqueKey(key, loadedTranslation.namespace);
           const phraseTranslationMessage =
             phraseAltTranslations[phraseKey]?.message;
 

--- a/packages/phrase/src/push-translations.test.ts
+++ b/packages/phrase/src/push-translations.test.ts
@@ -75,6 +75,17 @@ describe('push', () => {
                 "tags",
               ],
             },
+            "thanks.mytranslations": {
+              "global-key": "app.thanks.label",
+              "message": "Thanks",
+              "tags": [
+                "every",
+                "key",
+                "gets",
+                "these",
+                "tags",
+              ],
+            },
             "world.mytranslations": {
               "message": "world",
               "tags": [
@@ -139,6 +150,17 @@ describe('push', () => {
                 "tags": [
                   "only for this key",
                   "greeting",
+                  "every",
+                  "key",
+                  "gets",
+                  "these",
+                  "tags",
+                ],
+              },
+              "thanks.mytranslations": {
+                "global-key": "app.thanks.label",
+                "message": "Thanks",
+                "tags": [
                   "every",
                   "key",
                   "gets",


### PR DESCRIPTION
### Context
We want to map translations using custom keys instead of default keys

### Todos
- When doing a vocab pull, we are getting a list of translations from Phrase. If a local translation has a custom global-key key, we map the translation using the custom key instead of the default key.
- On global keys collide, throw error