### PR TITLE
Vocab pull: throw error if a local translation has a custom global ke…

### DIFF
--- a/.changeset/lemon-mails-battle.md
+++ b/.changeset/lemon-mails-battle.md
@@ -1,0 +1,5 @@
+---
+'@vocab/phrase': minor
+---
+
+Vocab push: support global key

--- a/.changeset/many-apricots-try.md
+++ b/.changeset/many-apricots-try.md
@@ -1,0 +1,6 @@
+---
+'@vocab/phrase': minor
+'@vocab/cli': minor
+---
+
+Vocab pull: throw error if a global key does not have translation in Phrase

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -44,7 +44,16 @@ yargs(process.argv.slice(2))
   })
   .command({
     command: 'pull',
-    builder: () => yargs.options({ branch: branchDefinition }),
+    builder: () =>
+      yargs.options({
+        branch: branchDefinition,
+        'error-on-no-global-key-translation': {
+          type: 'boolean',
+          describe:
+            'Whether or not to throw error when there is no translation for global key',
+          default: false,
+        },
+      }),
     handler: async (options) => {
       await pull(options, config!);
     },

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -16,12 +16,20 @@ jest.mock('./phrase-api', () => ({
 
 const devLanguage = 'en';
 
-function runPhrase(options: {
-  languages: LanguageTarget[];
-  generatedLanguages: GeneratedLanguageTarget[];
-}) {
+function runPhrase(
+  options: {
+    languages: LanguageTarget[];
+    generatedLanguages: GeneratedLanguageTarget[];
+  },
+  pullOptions?: {
+    errorOnNoGlobalKeyTranslation?: boolean;
+  },
+) {
   return pull(
-    { branch: 'tester' },
+    {
+      branch: 'tester',
+      errorOnNoGlobalKeyTranslation: pullOptions?.errorOnNoGlobalKeyTranslation,
+    },
     {
       ...options,
       devLanguage,
@@ -254,4 +262,51 @@ describe('pull translations', () => {
       expect(jest.mocked(writeFile)).toHaveBeenCalledTimes(0);
     });
   });
+
+  describe('when pulling translations and some global keys do not have any translations', () => {
+    beforeEach(() => {
+      jest.mocked(pullAllTranslations).mockClear();
+      jest.mocked(writeFile).mockClear();
+      jest.mocked(pullAllTranslations).mockImplementation(() =>
+        Promise.resolve({
+          en: {
+            'hello.mytranslations': {
+              message: 'Hi there',
+            },
+          },
+          fr: {
+            'hello.mytranslations': {
+              message: 'merci',
+            },
+          },
+        }),
+      );
+    });
+
+    const options = {
+      languages: [{ name: 'en' }, { name: 'fr' }],
+      generatedLanguages: [
+        {
+          name: 'generatedLanguage',
+          extends: 'en',
+          generator: {
+            transformMessage: (message: string) => `[${message}]`,
+          },
+        },
+      ],
+    };
+
+    it('should throw an error', async () => {
+      await expect(
+        runPhrase(options, {
+          errorOnNoGlobalKeyTranslation: true,
+        }),
+      ).rejects.toThrow(
+        new Error(`Missing translation for global key thanks in language fr`),
+      );
+
+      expect(jest.mocked(writeFile)).toHaveBeenCalledTimes(1);
+    });
+  });
+
 });

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -308,5 +308,4 @@ describe('pull translations', () => {
       expect(jest.mocked(writeFile)).toHaveBeenCalledTimes(1);
     });
   });
-
 });

--- a/packages/phrase/src/pull-translations.ts
+++ b/packages/phrase/src/pull-translations.ts
@@ -16,10 +16,11 @@ import { GLOBAL_KEY } from './config';
 interface PullOptions {
   branch?: string;
   deleteUnusedKeys?: boolean;
+  errorOnNoGlobalKeyTranslation?: boolean;
 }
 
 export async function pull(
-  { branch = 'local-development' }: PullOptions,
+  { branch = 'local-development', errorOnNoGlobalKeyTranslation }: PullOptions,
   config: UserConfig,
 ) {
   trace(`Pulling translations from branch ${branch}`);
@@ -97,6 +98,14 @@ export async function pull(
             trace(
               `Missing translation. No translation for key ${key} in phrase as ${phraseKey} in language ${alternativeLanguage}.`,
             );
+            if (
+              errorOnNoGlobalKeyTranslation &&
+              defaultValues[key][GLOBAL_KEY]
+            ) {
+              throw new Error(
+                `Missing translation for global key ${key} in language ${alternativeLanguage}`,
+              );
+            }
             continue;
           }
 


### PR DESCRIPTION
### Context
When doing Vocab pull, we are getting a list of translations from Phrase. If a local translation has a custom global-key key but there is no corresponding translation in Phrase, we want to throw error only if --error-on-no-global-key-translation feature flag is enabled

### To do
Add a feature flag `--error-on-no-global-key-translation` that will be consumed by Vocab pull