### PR TITLE
Add support for vocab.config.cjs

### DIFF
--- a/.changeset/tough-lamps-agree.md
+++ b/.changeset/tough-lamps-agree.md
@@ -1,0 +1,5 @@
+---
+"@vocab/core": minor
+---
+
+Add support for a alternative config file name, `vocab.config.cjs`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm i --save @vocab/core @vocab/react
 
 ### Step 2: Configure Vocab
 
-You can configure Vocab directly when calling the API or via a `vocab.config.js` file.
+You can configure Vocab directly when calling the API or via a `vocab.config.js` or `vocab.config.cjs` file.
 
 In this example we've configured two languages, English and French, where our initial `translation.json` files will use English.
 
@@ -184,7 +184,7 @@ t('my key with component', {
 
 ## Configuration
 
-Configuration can either be passed into the Node API directly or be gathered from the nearest _vocab.config.js_ file.
+Configuration can either be passed into the Node API directly or be gathered from the nearest _vocab.config.js_ or _vocab.config.cjs_ file.
 
 **vocab.config.js**
 
@@ -341,7 +341,7 @@ functionality.
 
 ### Generating a pseudo-localized language using Vocab
 
-Vocab can generate a pseudo-localized language via the [`generatedLanguages` config][generated languages config], either via the webpack plugin or your `vocab.config.js` file.
+Vocab can generate a pseudo-localized language via the [`generatedLanguages` config][generated languages config], either via the webpack plugin or your `vocab.config.js` or `vocab.config.cjs` file.
 `@vocab/pseudo-localize` exports a `generator` that can be used directly in your config.
 
 **vocab.config.js**

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -177,7 +177,7 @@ export async function resolveConfig(
 ): Promise<UserConfig | null> {
   const configFilePath = customConfigFilePath
     ? path.resolve(customConfigFilePath)
-    : await findUp('vocab.config.js');
+    : await findUp(['vocab.config.js', 'vocab.config.cjs']);
 
   if (configFilePath) {
     trace(`Resolved configuration file to ${configFilePath}`);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -192,7 +192,7 @@ export function resolveConfigSync(
 ): UserConfig | null {
   const configFilePath = customConfigFilePath
     ? path.resolve(customConfigFilePath)
-    : findUp.sync('vocab.config.js');
+    : findUp.sync(['vocab.config.js', 'vocab.config.cjs']);
 
   if (configFilePath) {
     trace(`Resolved configuration file to ${configFilePath}`);


### PR DESCRIPTION
## Context

Vocab currently supports vocab.config.js.

However, when using Vocab in ESM projects, Vocab may throw an error like this:

> Error [ERR_REQUIRE_ESM]: require() of ES Module /[project]/vocab.config.js from /[project]/node_modules/@vocab/core/dist/vocab-core.cjs.dev.js not supported.
>
> [1] vocab.config.js is treated as an ES module file as it is a .js file whose nearest parent package.json contains “type”: “module” which declares all .js files in that package scope as ES modules.

Vocab tries to do `require('./path/to/vocab.config.js')`, which shouldn't be possible inside an ESM workspace. vocab.config.js is assumed to be an ESM module, when it's actually a CJS module.

## Solution

This adds support for `vocab.config.cjs`.

## Caveats

Unfortunately, support for vocab.config.mjs won't be straight-forward.

A workaround is available as well: `vocab compile --config vocab.config.cjs`