### PR TITLE
Use puppeteer CLI to install browser in CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Install Puppeteer
         if: steps.puppeteer-cache.outputs.cache-hit != 'true'
-        run: node node_modules/puppeteer/install.mjs
+        run: pnpm puppeteer browsers install chrome
 
       - name: Build
         run: pnpm build


### PR DESCRIPTION
[Puppeteer 21.6.0](https://github.com/puppeteer/puppeteer/releases/tag/puppeteer-v21.6.0) added a CLI, which we can use instead of manually running the install script.