### PR TITLE
docs: Add JSdocs for `TranslationKeys`, `VocabProvider` and `useLanguage`

### DIFF
--- a/.changeset/mighty-waves-pump.md
+++ b/.changeset/mighty-waves-pump.md
@@ -1,0 +1,15 @@
+---
+'@vocab/core': patch
+---
+
+Enable the `TranslationKeys` type to operate on a union of translations
+
+**EXAMPLE USAGE**
+
+```tsx
+import { TranslationKeys } from '@vocab/core';
+import fooTranslations from './foo.vocab';
+import barTranslations from './bar.vocab';
+
+type FooBarTranslationKeys = TranslationKeys<typeof fooTranslations | typeof barTranslations>;
+```

--- a/.changeset/ninety-tomatoes-work.md
+++ b/.changeset/ninety-tomatoes-work.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+Add documentation to the `TranslationKeys` type

--- a/.changeset/yellow-months-sit.md
+++ b/.changeset/yellow-months-sit.md
@@ -1,0 +1,5 @@
+---
+'@vocab/react': patch
+---
+
+Add documentation for `VocabProvider` and `useLanguage`

--- a/README.md
+++ b/README.md
@@ -386,6 +386,32 @@ const MyComponent = () => {
 };
 ```
 
+## Translation Key Types
+
+If you need to access the keys of your translations as a TypeScript type, you can use the `TranslationKeys` type from `@vocab/core`:
+
+```jsonc
+// translations.json
+{
+  "Hello": {
+    "message": "Hello"
+  },
+  "Goodbye": {
+    "message": "Goodbye"
+  }
+}
+```
+
+```ts
+import type { TranslationKeys } from '@vocab/core';
+import translations from './.vocab';
+
+// "Hello" | "Goodbye"
+type MyTranslationKeys = TranslationKeys<
+  typeof translations
+>;
+```
+
 ## Generated languages
 
 Vocab supports the creation of generated languages via the `generatedLanguages` config.

--- a/fixtures/simple/src/client.tsx
+++ b/fixtures/simple/src/client.tsx
@@ -1,14 +1,23 @@
 import { VocabProvider, useTranslations } from '@vocab/react';
+import type { TranslationKeys } from '@vocab/core';
 import React, { type ReactNode, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import commonTranslations from './.vocab';
 import clientTranslations from './client.vocab';
 
+type CommonTranslationKeys = TranslationKeys<typeof commonTranslations>;
+
+const useCommonTranslation = (key: CommonTranslationKeys) => {
+  const { t } = useTranslations(commonTranslations);
+
+  return t(key);
+};
+
 function Content() {
   const common = useTranslations(commonTranslations);
   const client = useTranslations(clientTranslations);
-  const message = `${common.t('hello')} ${common.t('world')}`;
+  const message = `${common.t('hello')} ${useCommonTranslation('world')}`;
   const specialCharacterResult = client.t(
     'specialCharacters - \'‘’“”"!@#$%^&*()_+\\/`~\\\\',
   );

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -16,18 +16,60 @@ import React, {
 
 type Locale = string;
 
-interface TranslationsValue {
+interface TranslationsContextValue {
+  /**
+   * The `language` passed in to your `VocabProvider`
+   */
   language: LanguageName;
+  /**
+   * The `locale` passed in to your `VocabProvider`
+   *
+   * Please note that this value will be `undefined` if you have not passed a `locale` to your `VocabProvider`.
+   * If your languages are named with IETF language tags, you should just use `language` instead of
+   * this value, unless you specifically need to access your `locale` override.
+   */
   locale?: Locale;
 }
 
-const TranslationsContext = React.createContext<TranslationsValue | undefined>(
-  undefined,
-);
+const TranslationsContext = React.createContext<
+  TranslationsContextValue | undefined
+>(undefined);
 
-interface VocabProviderProps extends TranslationsValue {
+// Not extending TranslationsContextValue so we can tailor the docs for each prop to be better
+// suited to the provider, rather than for the useLanguage hook
+interface VocabProviderProps {
+  /**
+   * The language to load translations for. Must be one of the language names defined in your `vocab.config.js`.
+   */
+  language: TranslationsContextValue['language'];
+  /**
+   * A locale override. By default, Vocab will use the `language` as the locale when formatting messages if
+   * `locale` is not set. If your languages are named with IETF language tags, you probably don't need to
+   * set this value.
+   *
+   * You may want to override the locale for a specific language if the default formatting for that locale
+   * is not desired.
+   *
+   * @example
+   * // Override the locale for th-TH to use the Gregorian calendar instead of the default Buddhist calendar
+   * <VocabProvider language="th-TH" locale="th-TH-u-ca-gregory">
+   *   </App>
+   * <VocabProvider />
+   */
+  locale?: TranslationsContextValue['locale'];
   children: ReactNode;
 }
+
+/**
+ * Provides a translation context for your application
+ *
+ * @example
+ * import { VocabProvider } from '@vocab/react';
+ *
+ * <VocabProvider language="en">
+ *   <App />
+ * <VocabProvider />
+ */
 export const VocabProvider = ({
   children,
   language,
@@ -42,7 +84,10 @@ export const VocabProvider = ({
   );
 };
 
-export const useLanguage = (): TranslationsValue => {
+/**
+ * @returns The `language` and `locale` values passed in to your `VocabProvider`
+ */
+export const useLanguage = (): TranslationsContextValue => {
   const context = useContext(TranslationsContext);
   if (!context) {
     throw new Error(


### PR DESCRIPTION
Best viewed in your IDE so you can see the jsdocs in all their glory.