### PR TITLE
Add repo metadata to `package.json` files

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/cli",
   "version": "1.4.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/cli"
+  },
   "main": "dist/vocab-cli.cjs.js",
   "module": "dist/vocab-cli.esm.js",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/core",
   "version": "1.6.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/core"
+  },
   "main": "dist/vocab-core.cjs.js",
   "module": "dist/vocab-core.esm.js",
   "exports": {

--- a/packages/phrase/package.json
+++ b/packages/phrase/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/phrase",
   "version": "1.3.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/phrase"
+  },
   "main": "dist/vocab-phrase.cjs.js",
   "module": "dist/vocab-phrase.esm.js",
   "author": "SEEK",

--- a/packages/pseudo-localize/package.json
+++ b/packages/pseudo-localize/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/pseudo-localize",
   "version": "1.0.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/pseudo-localize"
+  },
   "main": "dist/vocab-pseudo-localize.cjs.js",
   "module": "dist/vocab-pseudo-localize.esm.js",
   "author": "SEEK",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/react",
   "version": "1.1.11",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/react"
+  },
   "main": "dist/vocab-react.cjs.js",
   "module": "dist/vocab-react.esm.js",
   "author": "SEEK",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/types",
   "version": "1.3.6",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/types"
+  },
   "main": "dist/vocab-types.cjs.js",
   "module": "dist/vocab-types.esm.js",
   "author": "SEEK",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@vocab/webpack",
   "version": "1.2.8",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/vocab.git",
+    "directory": "packages/webpack"
+  },
   "main": "dist/vocab-webpack.cjs.js",
   "module": "dist/vocab-webpack.esm.js",
   "exports": {


### PR DESCRIPTION
This metadata is shown on the npm page for packages, and it allows renovate to find the changelog for a package so it can show patch notes in PRs.