### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,1 @@
 * @seek-oss/vocab-maintainers
-
-# Configured by Renovate
-package.json
-yarn.lock


### PR DESCRIPTION
We don't use `yarn` anymore, and ignoring `package.json` files means PRs like #218 don't ping codeowners.