### PR TITLE
Use native FormData when uploading to Phrase

### DIFF
--- a/.changeset/cuddly-fans-drum.md
+++ b/.changeset/cuddly-fans-drum.md
@@ -1,0 +1,5 @@
+---
+'@vocab/cli': patch
+---
+
+Remove unused dependency on `form-data` npm package

--- a/.changeset/strange-candles-develop.md
+++ b/.changeset/strange-candles-develop.md
@@ -1,0 +1,9 @@
+---
+'@vocab/phrase': patch
+---
+
+Fix forbidden errors when pushing translations
+
+Migrate from `form-data` npm package to the native [Node FormData class](https://nodejs.org/api/globals.html#class-formdata) to ensure compatibility with the earlier move to native Fetch.
+
+Mixing the two was causing some consumers to receive 503 Forbidden errors when pushing translations to Phrase.

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ package-lock.json
 yarn-error.log
 yarn.lock
 .eslintcache
+
+.env

--- a/fixtures/phrase/package.json
+++ b/fixtures/phrase/package.json
@@ -3,5 +3,13 @@
   "description": "A playground reading and writing files for Phrase tests",
   "version": "1.0.0",
   "author": "SEEK",
-  "private": true
+  "private": true,
+  "scripts": {
+    "push": "dotenv vocab push",
+    "pull": "dotenv vocab pull"
+  },
+  "dependencies": {
+    "@vocab/cli": "workspace:*",
+    "dotenv-cli": "^7.2.1"
+  }
 }

--- a/fixtures/phrase/vocab.config.js
+++ b/fixtures/phrase/vocab.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  devLanguage: 'en',
+  languages: [{ name: 'en' }, { name: 'fr' }],
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "copy-readme-to-packages": "tsx scripts/copy-readme-to-packages",
     "start-fixture": "tsx test-helpers/src/start-fixture",
     "run-server-fixture": "tsx test-helpers/src/run-server-fixture",
-    "compile-fixtures": "pnpm --filter @vocab-fixtures/* compile"
+    "compile-fixtures": "pnpm --filter @vocab-fixtures/* compile",
+    "fixture:phrase:push": "pnpm run --filter @vocab-fixtures/phrase push",
+    "fixture:phrase:pull": "pnpm run --filter @vocab-fixtures/phrase pull"
   },
   "dependencies": {
     "@babel/core": "^7.12.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,6 @@
     "@vocab/phrase": "workspace:^",
     "env-ci": "^7.3.0",
     "fast-glob": "^3.2.4",
-    "form-data": "^4.0.0",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/phrase/package.json
+++ b/packages/phrase/package.json
@@ -17,7 +17,6 @@
     "@vocab/core": "workspace:^",
     "csv-stringify": "^6.2.3",
     "debug": "^4.3.1",
-    "form-data": "^4.0.0",
     "picocolors": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/phrase/src/phrase-api.ts
+++ b/packages/phrase/src/phrase-api.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-console */
-import FormData from 'form-data';
 import type { TranslationsByLanguage } from '@vocab/core';
 import { log, trace } from './logger';
 import { translationsToCsv } from './csv';
@@ -129,22 +128,24 @@ export async function pushTranslations(
   for (const [language, csvFileString] of Object.entries(csvFileStrings)) {
     const formData = new FormData();
 
-    const fileContents = Buffer.from(csvFileString);
-    formData.append('file', fileContents, {
-      contentType: 'text/csv',
-      filename: `${language}.translations.csv`,
-    });
+    formData.append(
+      'file',
+      new Blob([csvFileString], {
+        type: 'text/csv',
+      }),
+      `${language}.translations.csv`,
+    );
 
     formData.append('file_format', 'csv');
     formData.append('branch', branch);
     formData.append('update_translations', 'true');
     formData.append('update_descriptions', 'true');
 
-    formData.append(`locale_mapping[${language}]`, messageIndex);
+    formData.append(`locale_mapping[${language}]`, messageIndex.toString());
 
-    formData.append('format_options[key_index]', keyIndex);
-    formData.append('format_options[comment_index]', commentIndex);
-    formData.append('format_options[tag_column]', tagColumn);
+    formData.append('format_options[key_index]', keyIndex.toString());
+    formData.append('format_options[comment_index]', commentIndex.toString());
+    formData.append('format_options[tag_column]', tagColumn.toString());
     formData.append('format_options[enable_pluralization]', 'false');
 
     log(`Uploading translations for language ${language}`);
@@ -160,7 +161,7 @@ export async function pushTranslations(
       | undefined
     >(`uploads`, {
       method: 'POST',
-      body: formData.toString(),
+      body: formData,
     });
 
     trace('Upload result:\n', result);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,14 @@ importers:
         specifier: ^5.0.2
         version: 5.0.4(webpack@5.92.1)
 
-  fixtures/phrase: {}
+  fixtures/phrase:
+    dependencies:
+      '@vocab/cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      dotenv-cli:
+        specifier: ^7.2.1
+        version: 7.4.2
 
   fixtures/server:
     dependencies:
@@ -265,9 +272,6 @@ importers:
       fast-glob:
         specifier: ^3.2.4
         version: 3.3.2
-      form-data:
-        specifier: ^4.0.0
-        version: 4.0.0
       yargs:
         specifier: ^17.7.2
         version: 17.7.2
@@ -327,9 +331,6 @@ importers:
       debug:
         specifier: ^4.3.1
         version: 4.3.5
-      form-data:
-        specifier: ^4.0.0
-        version: 4.0.0
       picocolors:
         specifier: ^1.0.0
         version: 1.0.1
@@ -2661,6 +2662,18 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  dotenv-cli@7.4.2:
+    resolution: {integrity: sha512-SbUj8l61zIbzyhIbg0FwPJq6+wjbzdn9oEtozQpZ6kW2ihCcapKVZj49oCT3oPM+mgQm+itgvUQcG5szxVrZTA==}
+    hasBin: true
+
+  dotenv-expand@10.0.0:
+    resolution: {integrity: sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==}
+    engines: {node: '>=12'}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
 
   dotenv@8.6.0:
     resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
@@ -8171,6 +8184,17 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.6.3
+
+  dotenv-cli@7.4.2:
+    dependencies:
+      cross-spawn: 7.0.3
+      dotenv: 16.4.5
+      dotenv-expand: 10.0.0
+      minimist: 1.2.8
+
+  dotenv-expand@10.0.0: {}
+
+  dotenv@16.4.5: {}
 
   dotenv@8.6.0: {}
 


### PR DESCRIPTION
- Migrate from `form-data` to Node native FormData (Reasons in Changeset)
- Remove unused dependency in `form-data`. I believe this was in error
- Add test scripts to ensure Phrase fixture can be tested for above behaviour*

*The fixture changes could be split out to a seperate PR, but they help ensure the validity of this change so I'd like to combine them.

Closes: https://github.com/seek-oss/vocab/issues/253