### PR TITLE
Remove unnecessary `await` and loop

### DIFF
--- a/.changeset/many-rabbits-add.md
+++ b/.changeset/many-rabbits-add.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+`loadAllTranslations`: Refactor to remove unnecessary `await` and remove extra loop

--- a/packages/core/src/load-translations.ts
+++ b/packages/core/src/load-translations.ts
@@ -390,15 +390,17 @@ export async function loadAllTranslations(
 
   trace(`Found ${translationFiles.length} translation files`);
 
-  const result = await Promise.all(
-    translationFiles.map((filePath) =>
-      loadTranslation({ filePath, fallbacks, withTags }, config),
-    ),
-  );
-
+  const loadedTranslations: LoadedTranslation[] = [];
   const keys = new Set<string>();
 
-  for (const loadedTranslation of result) {
+  for (const translationFile of translationFiles) {
+    const loadedTranslation = loadTranslation(
+      { filePath: translationFile, fallbacks, withTags },
+      config,
+    );
+
+    loadedTranslations.push(loadedTranslation);
+
     for (const key of loadedTranslation.keys) {
       const uniqueKey = getUniqueKey(key, loadedTranslation.namespace);
       if (keys.has(uniqueKey)) {
@@ -421,5 +423,6 @@ export async function loadAllTranslations(
       }
     }
   }
-  return result;
+
+  return loadedTranslations;
 }


### PR DESCRIPTION
`loadTranslation` is actually synchronous, so it doesn't need to be wrapped inside a `promise.all`. This lets us just loop directly over `translationFiles`, rather than doing 2 loops.