### PR TITLE
`vite`: Vite plugin exclusive to non-ssr builds

### DIFF
--- a/.changeset/healthy-teachers-relax.md
+++ b/.changeset/healthy-teachers-relax.md
@@ -2,6 +2,6 @@
 '@vocab/vite': minor
 ---
 
-`vite`: Vite plugin limited to client-side builds.
+`vite`: Vite plugin limited to client-side builds
 
 The Vite plugin now runs exclusively during client-side builds. It will be skipped when using the *start* command and during server builds.

--- a/.changeset/healthy-teachers-relax.md
+++ b/.changeset/healthy-teachers-relax.md
@@ -1,0 +1,7 @@
+---
+'@vocab/vite': minor
+---
+
+`vite`: Vite plugin limited to client-side builds.
+
+The Vite plugin now runs exclusively during client-side builds. It will be skipped when using the *start* command and during server builds.

--- a/.changeset/healthy-teachers-relax.md
+++ b/.changeset/healthy-teachers-relax.md
@@ -2,6 +2,6 @@
 '@vocab/vite': minor
 ---
 
-`vite`: Vite plugin limited to client-side builds
+`vite`: Vite plugin exclusive to non-ssr builds
 
-The Vite plugin now runs exclusively during client-side builds. It will be skipped when using the *start* command and during server builds.
+The Vocab Vite plugin now runs exclusively during build-time, and only when build.ssr: false

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -196,6 +196,13 @@ describe('pull translations', () => {
       ).toMatchInlineSnapshot(`
         [
           {
+            "_meta": {},
+            "excluded": {
+              "message": "this is excluded",
+            },
+          },
+          {},
+          {
             "_meta": {
               "tags": [
                 "every",
@@ -234,13 +241,6 @@ describe('pull translations', () => {
               "message": "monde",
             },
           },
-          {
-            "_meta": {},
-            "excluded": {
-              "message": "this is excluded",
-            },
-          },
-          {},
         ]
       `);
     });

--- a/packages/phrase/src/pull-translations.test.ts
+++ b/packages/phrase/src/pull-translations.test.ts
@@ -196,13 +196,6 @@ describe('pull translations', () => {
       ).toMatchInlineSnapshot(`
         [
           {
-            "_meta": {},
-            "excluded": {
-              "message": "this is excluded",
-            },
-          },
-          {},
-          {
             "_meta": {
               "tags": [
                 "every",
@@ -241,6 +234,13 @@ describe('pull translations', () => {
               "message": "monde",
             },
           },
+          {
+            "_meta": {},
+            "excluded": {
+              "message": "this is excluded",
+            },
+          },
+          {},
         ]
       `);
     });

--- a/packages/vite/src/create-vocab-chunks.ts
+++ b/packages/vite/src/create-vocab-chunks.ts
@@ -1,13 +1,17 @@
 import type { Rollup } from 'vite';
 import { trace as _trace } from './logger';
+import { getChunkName } from './get-chunk-name';
 
 const trace = _trace.extend('create-vocab-chunks');
 
+/**
+ * Gets vocab virtual module details and creates chunks for each language
+ */
 export const createVocabChunks = (
   id: string,
   { getModuleInfo }: Rollup.ManualChunkMeta,
 ) => {
-  const match = /(\w+)-virtual:vocab/.exec(id);
+  const match = /virtual:vocab-(\w+)/.exec(id);
   if (!match) {
     return;
   }
@@ -19,9 +23,10 @@ export const createVocabChunks = (
 
   if (!rootModuleInfo) {
     trace(`No module info found for ${id}`);
+    return;
   }
 
-  const idsToHandle = new Set<string>(getModuleInfo(id)?.dynamicImporters);
+  const idsToHandle = new Set<string>(rootModuleInfo.dynamicImporters);
 
   for (const moduleId of idsToHandle) {
     const moduleInfo = getModuleInfo(moduleId);
@@ -40,6 +45,6 @@ export const createVocabChunks = (
   }
 
   if (dependentEntryPoints.length > 0) {
-    return `${language}-translations`;
+    return getChunkName(language);
   }
 };

--- a/packages/vite/src/get-chunk-name.ts
+++ b/packages/vite/src/get-chunk-name.ts
@@ -1,0 +1,3 @@
+export function getChunkName(lang: string) {
+  return `${lang}-translations`;
+}

--- a/packages/vite/src/transform-vocab-file.ts
+++ b/packages/vite/src/transform-vocab-file.ts
@@ -111,5 +111,5 @@ const createIdentifier = (
 
   const encodedResource = `${sourceQueryKey}${base64}`;
 
-  return `./${lang}-${virtualModuleId}.json${encodedResource}`;
+  return `${virtualModuleId}-${lang}.json${encodedResource}`;
 };

--- a/tests/__snapshots__/E2E.test.ts.snap
+++ b/tests/__snapshots__/E2E.test.ts.snap
@@ -82,16 +82,16 @@ module.exports = /*#__PURE__*/JSON.parse('{"specialCharacters - \\'‘’“”\
 `;
 
 exports[`E2E vite with plugin should return the expected en chunk 1`] = `
-"const e="Hello",o="world",l={hello:e,world:o},r=Object.freeze(Object.defineProperty({__proto__:null,default:l,hello:e,world:o},Symbol.toStringTag,{value:"Module"})),t="<strong>Vocab</strong> was published on {publishDate, date, small}",a={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\",vocabPublishDate:t},c=Object.freeze(Object.defineProperty({__proto__:null,default:a,vocabPublishDate:t},Symbol.toStringTag,{value:"Module"}));export{c as a,r as e};
+"const o="Hello",e="world",l={hello:o,world:e},r=Object.freeze(Object.defineProperty({__proto__:null,default:l,hello:o,world:e},Symbol.toStringTag,{value:"Module"})),t="<strong>Vocab</strong> was published on {publishDate, date, small}",a={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\",vocabPublishDate:t},c=Object.freeze(Object.defineProperty({__proto__:null,default:a,vocabPublishDate:t},Symbol.toStringTag,{value:"Module"}));export{r as _,c as a};
 "
 `;
 
 exports[`E2E vite with plugin should return the expected fr chunk 1`] = `
-"const e="Bonjour",o="monde",a={hello:e,world:o},r=Object.freeze(Object.defineProperty({__proto__:null,default:a,hello:e,world:o},Symbol.toStringTag,{value:"Module"})),t="Vocab a été publié le {publishDate, date, medium}",l={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\",vocabPublishDate:t},c=Object.freeze(Object.defineProperty({__proto__:null,default:l,vocabPublishDate:t},Symbol.toStringTag,{value:"Module"}));export{c as a,r as f};
+"const e="Bonjour",o="monde",a={hello:e,world:o},r=Object.freeze(Object.defineProperty({__proto__:null,default:a,hello:e,world:o},Symbol.toStringTag,{value:"Module"})),t="Vocab a été publié le {publishDate, date, medium}",l={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\",vocabPublishDate:t},c=Object.freeze(Object.defineProperty({__proto__:null,default:l,vocabPublishDate:t},Symbol.toStringTag,{value:"Module"}));export{r as _,c as a};
 "
 `;
 
 exports[`E2E vite with plugin should return the expected pseudo chunk 1`] = `
-"const o="[Ḩẽẽƚƚöö]",t="[ŵöööřƚƌ]",s={hello:o,world:t},b=Object.freeze(Object.defineProperty({__proto__:null,default:s,hello:o,world:t},Symbol.toStringTag,{value:"Module"})),e="[<strong>Ṽööçăăß</strong> ŵăăăš ƥǚǚǚßƚìììšḩẽẽẽƌ öööกี้ {publishDate, date, small}]",l={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"[‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\]",vocabPublishDate:e},a=Object.freeze(Object.defineProperty({__proto__:null,default:l,vocabPublishDate:e},Symbol.toStringTag,{value:"Module"}));export{a as G,b as p};
+"const o="[Ḩẽẽƚƚöö]",t="[ŵöööřƚƌ]",s={hello:o,world:t},b=Object.freeze(Object.defineProperty({__proto__:null,default:s,hello:o,world:t},Symbol.toStringTag,{value:"Module"})),e="[<strong>Ṽööçăăß</strong> ŵăăăš ƥǚǚǚßƚìììšḩẽẽẽƌ öööกี้ {publishDate, date, small}]",l={"specialCharacters - '‘’“”\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\":"[‘’“”'\\"!@#$%^&*()_+\\\\/\`~\\\\\\\\]",vocabPublishDate:e},a=Object.freeze(Object.defineProperty({__proto__:null,default:l,vocabPublishDate:e},Symbol.toStringTag,{value:"Module"}));export{a as G,b as _};
 "
 `;


### PR DESCRIPTION
The Vocab Vite plugin now runs exclusively during build-time, and only when `build.ssr: false` ([Vite docs](https://vite.dev/config/build-options.html#build-ssr)).

The internal virtual module name has also been updated to `virtual:vocab-${lang}` to better match Vite naming conventions.