### PR TITLE
`vite`: Releasing vocab vite plugin

### DIFF
--- a/.changeset/gorgeous-singers-sniff.md
+++ b/.changeset/gorgeous-singers-sniff.md
@@ -1,0 +1,5 @@
+---
+'@vocab/vite': patch
+---
+
+Releasing @vocab/vite in v0 to signify an experimental release

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "author": "SEEK",
   "license": "MIT",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/seek-oss/vocab.git",


### PR DESCRIPTION
The Vocab Vite plugin can now be released since it has now been tested and shown to work with a Vite app. The plugin is still experimental and may not be stable on future releases, so it is not a v1 release just yet.