### PR TITLE
`vite`: Exposing `getChunkName` function for Vite multi-language support

### DIFF
--- a/.changeset/short-melons-dress.md
+++ b/.changeset/short-melons-dress.md
@@ -1,0 +1,5 @@
+---
+'@vocab/vite': minor
+---
+
+`vite`: Exposing `getChunkName` function for Vite multi-language support

--- a/.changeset/short-melons-dress.md
+++ b/.changeset/short-melons-dress.md
@@ -2,4 +2,18 @@
 '@vocab/vite': minor
 ---
 
-`vite`: Exposing `getChunkName` function for Vite multi-language support
+`vite`: Rename exports in the Vite plugin
+
+> Note: This is a breaking change if you used either of the exports below, however, since this plugin is still experimental it is being released as a minor change.
+
+### Renamed exports
+
+Moves a few of the Vite plugin functions under different export paths for better organisation. The functions themselves have not changed, only their exported location.
+
+* `@vocab/vite/create-language` -> `@vocab/vite/runtime`
+* `@vocab/vite/create-vocab-chunks` -> `@vocab/vite/chunks`
+
+### New function available
+
+A `getChunkName` function is now exported under `@vocab/vite/chunks`.
+ 

--- a/fixtures/vite/vite.config.js
+++ b/fixtures/vite/vite.config.js
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vite';
 import vitePluginVocab from '@vocab/vite';
-import { createVocabChunks } from '@vocab/vite/create-vocab-chunks';
+import { createVocabChunks } from '@vocab/vite/chunks';
 import vocabConfig from './vocab.config.cjs';
 
 export default defineConfig({

--- a/packages/vite/chunks/package.json
+++ b/packages/vite/chunks/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/vocab-vite-chunks.cjs.js",
+  "module": "dist/vocab-vite-chunks.esm.js"
+}

--- a/packages/vite/create-language/package.json
+++ b/packages/vite/create-language/package.json
@@ -1,4 +1,0 @@
-{
-  "main": "dist/vocab-vite-create-language.cjs.js",
-  "module": "dist/vocab-vite-create-language.esm.js"
-}

--- a/packages/vite/create-vocab-chunks/package.json
+++ b/packages/vite/create-vocab-chunks/package.json
@@ -1,4 +1,0 @@
-{
-  "main": "dist/vocab-vite-create-vocab-chunks.cjs.js",
-  "module": "dist/vocab-vite-create-vocab-chunks.esm.js"
-}

--- a/packages/vite/get-chunk-name/package.json
+++ b/packages/vite/get-chunk-name/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/vocab-vite-get-chunk-name.cjs.js",
+  "module": "dist/vocab-vite-get-chunk-name.esm.js"
+}

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -16,32 +16,26 @@
       "module": "./dist/vocab-vite.esm.js",
       "default": "./dist/vocab-vite.cjs.js"
     },
-    "./create-language": {
-      "module": "./create-language/dist/vocab-vite-create-language.esm.js",
-      "default": "./create-language/dist/vocab-vite-create-language.cjs.js"
+    "./runtime": {
+      "module": "./runtime/dist/vocab-vite-runtime.esm.js",
+      "default": "./runtime/dist/vocab-vite-runtime.cjs.js"
     },
-    "./create-vocab-chunks": {
-      "module": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.esm.js",
-      "default": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.cjs.js"
-    },
-    "./chunk-name": {
-      "module": "./get-chunk-name/dist/vocab-vite-get-chunk-name.esm.js",
-      "default": "./get-chunk-name/dist/vocab-vite-get-chunk-name.cjs.js"
+    "./chunks": {
+      "module": "./chunks/dist/vocab-vite-chunks.esm.js",
+      "default": "./chunks/dist/vocab-vite-chunks.cjs.js"
     }
   },
   "preconstruct": {
     "entrypoints": [
       "index.ts",
-      "create-language.ts",
-      "create-vocab-chunks.ts",
-      "get-chunk-name.ts"
+      "runtime.ts",
+      "chunks.ts"
     ]
   },
   "files": [
     "dist",
-    "create-language",
-    "create-vocab-chunks",
-    "get-chunk-name"
+    "runtime",
+    "chunks"
   ],
   "dependencies": {
     "@vocab/core": "workspace:^",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -24,7 +24,7 @@
       "module": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.esm.js",
       "default": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.cjs.js"
     },
-    "./get-chunk-name": {
+    "./chunk-name": {
       "module": "./get-chunk-name/dist/vocab-vite-get-chunk-name.esm.js",
       "default": "./get-chunk-name/dist/vocab-vite-get-chunk-name.cjs.js"
     }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -23,19 +23,25 @@
     "./create-vocab-chunks": {
       "module": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.esm.js",
       "default": "./create-vocab-chunks/dist/vocab-vite-create-vocab-chunks.cjs.js"
+    },
+    "./get-chunk-name": {
+      "module": "./get-chunk-name/dist/vocab-vite-get-chunk-name.esm.js",
+      "default": "./get-chunk-name/dist/vocab-vite-get-chunk-name.cjs.js"
     }
   },
   "preconstruct": {
     "entrypoints": [
       "index.ts",
       "create-language.ts",
-      "create-vocab-chunks.ts"
+      "create-vocab-chunks.ts",
+      "get-chunk-name.ts"
     ]
   },
   "files": [
     "dist",
     "create-language",
-    "create-vocab-chunks"
+    "create-vocab-chunks",
+    "get-chunk-name"
   ],
   "dependencies": {
     "@vocab/core": "workspace:^",

--- a/packages/vite/runtime/package.json
+++ b/packages/vite/runtime/package.json
@@ -1,0 +1,4 @@
+{
+  "main": "dist/vocab-vite-runtime.cjs.js",
+  "module": "dist/vocab-vite-runtime.esm.js"
+}

--- a/packages/vite/src/chunks.ts
+++ b/packages/vite/src/chunks.ts
@@ -1,0 +1,2 @@
+export { createVocabChunks } from './create-vocab-chunks';
+export { getChunkName } from './get-chunk-name';

--- a/packages/vite/src/create-language.ts
+++ b/packages/vite/src/create-language.ts
@@ -1,8 +1,6 @@
 import type { TranslationModule } from '@vocab/core';
 import { getParsedICUMessages } from '@vocab/core/icu-handler';
 
-export { createTranslationFile } from '@vocab/core/translation-file';
-
 export const createLanguage = (
   loadImport: () => Promise<any>,
 ): TranslationModule<any> => {

--- a/packages/vite/src/runtime.ts
+++ b/packages/vite/src/runtime.ts
@@ -1,1 +1,2 @@
+export { createTranslationFile } from '@vocab/core/translation-file';
 export { createLanguage } from './create-language';

--- a/packages/vite/src/runtime.ts
+++ b/packages/vite/src/runtime.ts
@@ -1,0 +1,1 @@
+export { createLanguage } from './create-language';

--- a/packages/vite/src/transform-vocab-file.ts
+++ b/packages/vite/src/transform-vocab-file.ts
@@ -62,7 +62,7 @@ export const transformVocabFile = async (
     trace(`Found ESM export '${exportName.n}' in ${id}`);
 
     result = /* ts */ `
-      import { createLanguage, createTranslationFile } from '@vocab/vite/create-language';
+      import { createLanguage, createTranslationFile } from '@vocab/vite/runtime';
       ${translations}
       export { translations as ${exportName.n} };
     `;
@@ -74,7 +74,7 @@ export const transformVocabFile = async (
     trace(`Found CJS export '${exportName}' in ${id}`);
 
     result = /* ts */ `
-      import { createLanguage, createTranslationFile } from '@vocab/vite/create-language';
+      import { createLanguage, createTranslationFile } from '@vocab/vite/runtime';
       ${translations}
       exports.${exportName} = translations;
     `;


### PR DESCRIPTION
The Vocab webpack plugin exposes a `getChunkName` function that can be used to get the names of language chunks generated by the webpack Vocab plugin (useful for Webpack plugin developers). The Vite plugin has it's own function to do this, but was previously not exported. This change exposes Vites `getChunkName` function.