### PR TITLE
Update `prettier` to v3

### DIFF
--- a/.changeset/selfish-suns-roll.md
+++ b/.changeset/selfish-suns-roll.md
@@ -1,0 +1,5 @@
+---
+'@vocab/core': patch
+---
+
+Update `prettier` to v3

--- a/fixtures/vite/index.html
+++ b/fixtures/vite/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "fast-glob": "^3.2.4",
     "jest": "^29.4.3",
     "jest-puppeteer": "^10.1.0",
-    "prettier": "^2.1.2",
+    "prettier": "^3.5.3",
     "puppeteer": "^23.0.0",
     "tsx": "^4.10.5",
     "typescript": "^5.5.4",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -52,10 +52,9 @@
     "find-up": "^5.0.0",
     "intl-messageformat": "^10.0.0",
     "picocolors": "^1.0.0",
-    "prettier": "^2.1.2"
+    "prettier": "^3.5.3"
   },
   "devDependencies": {
-    "@types/debug": "^4.1.5",
-    "@types/prettier": "^2.1.5"
+    "@types/debug": "^4.1.5"
   }
 }

--- a/packages/core/src/compile.ts
+++ b/packages/core/src/compile.ts
@@ -236,7 +236,7 @@ export async function generateRuntime(loadedTranslation: LoadedTranslation) {
     imports,
     loadedTranslation,
   );
-  const declaration = prettier.format(serializedTranslationType, {
+  const declaration = await prettier.format(serializedTranslationType, {
     ...prettierConfig,
     parser: 'typescript',
   });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^10.1.0
         version: 10.1.4(puppeteer@23.11.1(typescript@5.7.3))(typescript@5.7.3)
       prettier:
-        specifier: ^2.1.2
-        version: 2.8.8
+        specifier: ^3.5.3
+        version: 3.5.3
       puppeteer:
         specifier: ^23.0.0
         version: 23.11.1(typescript@5.7.3)
@@ -346,15 +346,12 @@ importers:
         specifier: ^1.0.0
         version: 1.1.1
       prettier:
-        specifier: ^2.1.2
-        version: 2.8.8
+        specifier: ^3.5.3
+        version: 3.5.3
     devDependencies:
       '@types/debug':
         specifier: ^4.1.5
         version: 4.1.12
-      '@types/prettier':
-        specifier: ^2.1.5
-        version: 2.7.3
 
   packages/phrase:
     dependencies:
@@ -2024,9 +2021,6 @@ packages:
 
   '@types/node@18.19.74':
     resolution: {integrity: sha512-HMwEkkifei3L605gFdV+/UwtpxP6JSzM+xFk2Ia6DNFSwSVBRh9qp5Tgf4lNFOMfPVuU0WnkcWpXZpgn5ufO4A==}
-
-  '@types/prettier@2.7.3':
-    resolution: {integrity: sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==}
 
   '@types/prop-types@15.7.14':
     resolution: {integrity: sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==}
@@ -4452,6 +4446,11 @@ packages:
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.5.3:
+    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-error@4.0.0:
@@ -7184,8 +7183,6 @@ snapshots:
   '@types/node@18.19.74':
     dependencies:
       undici-types: 5.26.5
-
-  '@types/prettier@2.7.3': {}
 
   '@types/prop-types@15.7.14': {}
 
@@ -10118,6 +10115,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
+
+  prettier@3.5.3: {}
 
   pretty-error@4.0.0:
     dependencies:


### PR DESCRIPTION
This may result in different formatting of the compiled runtime files generated by `vocab compile`, but that's inconsequential to vocab's API so should be an uncontroversial update.