### PR TITLE
bumping React deps to v19

### DIFF
--- a/fixtures/direct/package.json
+++ b/fixtures/direct/package.json
@@ -9,16 +9,16 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.0",
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.4",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vocab/cli": "workspace:*",
     "@vocab/core": "workspace:*",
     "@vocab/pseudo-localize": "workspace:*",
     "@vocab/webpack": "workspace:*",
     "babel-loader": "^9.1.2",
     "html-webpack-plugin": "^5.5.0",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "webpack": "^5.37.0",
     "webpack-dev-server": "^5.0.2"
   }

--- a/fixtures/server/package.json
+++ b/fixtures/server/package.json
@@ -18,8 +18,8 @@
     "@types/loadable__server": "^5.12.3",
     "@types/loadable__webpack-plugin": "^5.7.1",
     "@types/node": "^18.11.9",
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.4",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@types/start-server-webpack-plugin": "^2.2.0",
     "@vocab/cli": "workspace:*",
     "@vocab/core": "workspace:*",
@@ -29,8 +29,8 @@
     "babel-loader": "^9.1.2",
     "express": "^4.17.1",
     "html-webpack-plugin": "^5.5.0",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "webpack": "^5.37.0"
   }
 }

--- a/fixtures/simple/package.json
+++ b/fixtures/simple/package.json
@@ -9,8 +9,8 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.0",
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.4",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vocab/cli": "workspace:*",
     "@vocab/core": "workspace:*",
     "@vocab/pseudo-localize": "workspace:*",
@@ -18,8 +18,8 @@
     "@vocab/webpack": "workspace:*",
     "babel-loader": "^9.1.2",
     "html-webpack-plugin": "^5.5.0",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "webpack": "^5.37.0",
     "webpack-dev-server": "^5.0.2"
   }

--- a/fixtures/vite/package.json
+++ b/fixtures/vite/package.json
@@ -11,15 +11,15 @@
   },
   "dependencies": {
     "@babel/core": "^7.12.0",
-    "@types/react": "^18.0.9",
-    "@types/react-dom": "^18.0.4",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
     "@vocab/cli": "workspace:*",
     "@vocab/core": "workspace:*",
     "@vocab/pseudo-localize": "workspace:*",
     "@vocab/react": "workspace:*",
     "@vocab/vite": "workspace:*",
-    "react": "^18.1.0",
-    "react-dom": "^18.1.0",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "vite": "^6.3.5"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -21,7 +21,7 @@
     "intl-messageformat": "^10.0.0"
   },
   "devDependencies": {
-    "@types/react": "^18.0.9",
-    "react": "^18.1.0"
+    "@types/react": "^19.1.8",
+    "react": "^19.1.0"
   }
 }

--- a/packages/react/src/index.tsx
+++ b/packages/react/src/index.tsx
@@ -4,6 +4,7 @@ import type {
   ParsedFormatFnByKey,
   ParsedFormatFn,
 } from '@vocab/core';
+
 import React, {
   type ReactNode,
   useContext,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,11 +84,11 @@ importers:
         specifier: ^7.12.0
         version: 7.28.0
       '@types/react':
-        specifier: ^18.0.9
-        version: 18.3.23
+        specifier: ^19.1.8
+        version: 19.1.8
       '@types/react-dom':
-        specifier: ^18.0.4
-        version: 18.3.7(@types/react@18.3.23)
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.8)
       '@vocab/cli':
         specifier: workspace:*
         version: link:../../packages/cli
@@ -108,11 +108,11 @@ importers:
         specifier: ^5.5.0
         version: 5.6.3(webpack@5.99.9)
       react:
-        specifier: ^18.1.0
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
       react-dom:
-        specifier: ^18.1.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       webpack:
         specifier: ^5.37.0
         version: 5.99.9
@@ -139,10 +139,10 @@ importers:
         version: 5.16.1(@babel/core@7.28.0)
       '@loadable/component':
         specifier: ^5.14.1
-        version: 5.16.7(react@18.3.1)
+        version: 5.16.7(react@19.1.0)
       '@loadable/server':
         specifier: ^5.14.0
-        version: 5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)
+        version: 5.16.7(@loadable/component@5.16.7(react@19.1.0))(react@19.1.0)
       '@loadable/webpack-plugin':
         specifier: ^5.14.0
         version: 5.15.2(webpack@5.99.9)
@@ -162,11 +162,11 @@ importers:
         specifier: ^18.11.9
         version: 18.19.115
       '@types/react':
-        specifier: ^18.0.9
-        version: 18.3.23
+        specifier: ^19.1.8
+        version: 19.1.8
       '@types/react-dom':
-        specifier: ^18.0.4
-        version: 18.3.7(@types/react@18.3.23)
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.8)
       '@types/start-server-webpack-plugin':
         specifier: ^2.2.0
         version: 2.2.5
@@ -195,11 +195,11 @@ importers:
         specifier: ^5.5.0
         version: 5.6.3(webpack@5.99.9)
       react:
-        specifier: ^18.1.0
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
       react-dom:
-        specifier: ^18.1.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       webpack:
         specifier: ^5.37.0
         version: 5.99.9
@@ -210,11 +210,11 @@ importers:
         specifier: ^7.12.0
         version: 7.28.0
       '@types/react':
-        specifier: ^18.0.9
-        version: 18.3.23
+        specifier: ^19.1.8
+        version: 19.1.8
       '@types/react-dom':
-        specifier: ^18.0.4
-        version: 18.3.7(@types/react@18.3.23)
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.8)
       '@vocab/cli':
         specifier: workspace:*
         version: link:../../packages/cli
@@ -237,11 +237,11 @@ importers:
         specifier: ^5.5.0
         version: 5.6.3(webpack@5.99.9)
       react:
-        specifier: ^18.1.0
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
       react-dom:
-        specifier: ^18.1.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       webpack:
         specifier: ^5.37.0
         version: 5.99.9
@@ -264,11 +264,11 @@ importers:
         specifier: ^7.12.0
         version: 7.28.0
       '@types/react':
-        specifier: ^18.0.9
-        version: 18.3.23
+        specifier: ^19.1.8
+        version: 19.1.8
       '@types/react-dom':
-        specifier: ^18.0.4
-        version: 18.3.7(@types/react@18.3.23)
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.8)
       '@vocab/cli':
         specifier: workspace:*
         version: link:../../packages/cli
@@ -285,11 +285,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/vite
       react:
-        specifier: ^18.1.0
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
       react-dom:
-        specifier: ^18.1.0
-        version: 18.3.1(react@18.3.1)
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       vite:
         specifier: ^6.3.5
         version: 6.3.5(@types/node@18.19.115)(terser@5.43.1)(tsx@4.20.3)
@@ -387,11 +387,11 @@ importers:
         version: 10.7.16
     devDependencies:
       '@types/react':
-        specifier: ^18.0.9
-        version: 18.3.23
+        specifier: ^19.1.8
+        version: 19.1.8
       react:
-        specifier: ^18.1.0
-        version: 18.3.1
+        specifier: ^19.1.0
+        version: 19.1.0
 
   packages/types:
     dependencies:
@@ -1904,22 +1904,19 @@ packages:
   '@types/node@18.19.115':
     resolution: {integrity: sha512-kNrFiTgG4a9JAn1LMQeLOv3MvXIPokzXziohMrMsvpYgLpdEt/mMiVYc4sGKtDfyxM5gIDF4VgrPRyCw4fHOYg==}
 
-  '@types/prop-types@15.7.15':
-    resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
-
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
   '@types/range-parser@1.2.7':
     resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
 
-  '@types/react-dom@18.3.7':
-    resolution: {integrity: sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==}
+  '@types/react-dom@19.1.6':
+    resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
     peerDependencies:
-      '@types/react': ^18.0.0
+      '@types/react': ^19.0.0
 
-  '@types/react@18.3.23':
-    resolution: {integrity: sha512-/LDXMQh55EzZQ0uVAZmKKhfENivEvWz6E+EYzh+/MCjMhNsotd+ZHhBGIjFDTi6+fz0OhQQQLbTgdQIxxCsC0w==}
+  '@types/react@19.1.8':
+    resolution: {integrity: sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==}
 
   '@types/resolve@1.17.1':
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==}
@@ -4540,10 +4537,10 @@ packages:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
 
-  react-dom@18.3.1:
-    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+  react-dom@19.1.0:
+    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
     peerDependencies:
-      react: ^18.3.1
+      react: ^19.1.0
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4551,8 +4548,8 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react@18.3.1:
-    resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
+  react@19.1.0:
+    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
@@ -4703,8 +4700,8 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
-  scheduler@0.23.2:
-    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+  scheduler@0.26.0:
+    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
   schema-utils@4.3.2:
     resolution: {integrity: sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==}
@@ -6743,18 +6740,18 @@ snapshots:
       '@babel/core': 7.28.0
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.28.0)
 
-  '@loadable/component@5.16.7(react@18.3.1)':
+  '@loadable/component@5.16.7(react@19.1.0)':
     dependencies:
       '@babel/runtime': 7.27.6
       hoist-non-react-statics: 3.3.2
-      react: 18.3.1
+      react: 19.1.0
       react-is: 16.13.1
 
-  '@loadable/server@5.16.7(@loadable/component@5.16.7(react@18.3.1))(react@18.3.1)':
+  '@loadable/server@5.16.7(@loadable/component@5.16.7(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@loadable/component': 5.16.7(react@18.3.1)
+      '@loadable/component': 5.16.7(react@19.1.0)
       lodash: 4.17.21
-      react: 18.3.1
+      react: 19.1.0
 
   '@loadable/webpack-plugin@5.15.2(webpack@5.99.9)':
     dependencies:
@@ -7134,11 +7131,11 @@ snapshots:
 
   '@types/loadable__component@5.13.9':
     dependencies:
-      '@types/react': 18.3.23
+      '@types/react': 19.1.8
 
   '@types/loadable__server@5.12.11':
     dependencies:
-      '@types/react': 18.3.23
+      '@types/react': 19.1.8
 
   '@types/loadable__webpack-plugin@5.15.0':
     dependencies:
@@ -7158,19 +7155,16 @@ snapshots:
     dependencies:
       undici-types: 5.26.5
 
-  '@types/prop-types@15.7.15': {}
-
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
 
-  '@types/react-dom@18.3.7(@types/react@18.3.23)':
+  '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
-      '@types/react': 18.3.23
+      '@types/react': 19.1.8
 
-  '@types/react@18.3.23':
+  '@types/react@19.1.8':
     dependencies:
-      '@types/prop-types': 15.7.15
       csstype: 3.1.3
 
   '@types/resolve@1.17.1':
@@ -10259,19 +10253,16 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dom@18.3.1(react@18.3.1):
+  react-dom@19.1.0(react@19.1.0):
     dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
+      react: 19.1.0
+      scheduler: 0.26.0
 
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
 
-  react@18.3.1:
-    dependencies:
-      loose-envify: 1.4.0
+  react@19.1.0: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -10463,9 +10454,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  scheduler@0.23.2:
-    dependencies:
-      loose-envify: 1.4.0
+  scheduler@0.26.0: {}
 
   schema-utils@4.3.2:
     dependencies:


### PR DESCRIPTION
Bumping React dependancies to React 19. The peer dependancy is already in a range that supports it so this update doesn't need a release and is only for us to make sure our tests pass with React 19. 