### PR TITLE
Cleanup dev script use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,7 @@ yarn.lock
 .eslintcache
 
 .env
+
+.pnpm-store/
+.cursor/
+.claude/

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "url": "git+https://github.com/seek-oss/vocab.git"
   },
   "scripts": {
-    "start:direct": "pnpm dev && pnpm --filter @vocab-fixtures/direct compile && pnpm start-fixture direct",
-    "start:server": "pnpm dev && pnpm --filter @vocab-fixtures/server compile && pnpm start-fixture server",
-    "start:simple": "pnpm dev && pnpm --filter @vocab-fixtures/simple compile && pnpm start-fixture simple",
-    "start:vite": "pnpm dev && pnpm --filter @vocab-fixtures/vite compile && pnpm preview-vite-fixture vite",
+    "start:direct": "pnpm --filter @vocab-fixtures/direct compile && pnpm start-fixture direct",
+    "start:server": "pnpm --filter @vocab-fixtures/server compile && pnpm start-fixture server",
+    "start:simple": "pnpm --filter @vocab-fixtures/simple compile && pnpm start-fixture simple",
+    "start:vite": "pnpm --filter @vocab-fixtures/vite compile && pnpm preview-vite-fixture vite",
     "build": "tsdown",
     "format": "pnpm run --stream '/^format:.*/'",
     "format:eslint": "eslint --fix --cache .",


### PR DESCRIPTION
`pnpm dev` is nolonger required when running start scripts since [removing pre-construct](https://github.com/seek-oss/vocab/pull/330/changes#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L21).


