### PR TITLE
Keep previous translations visible while the next language loads

### DIFF
--- a/.changeset/quiet-apples-remain.md
+++ b/.changeset/quiet-apples-remain.md
@@ -1,0 +1,7 @@
+---
+'@vocab/react': patch
+---
+
+Keep the previous language's messages on screen while the next language chunk loads.
+
+Previously, switching language rendered a blank string until the new translations resolved, which looked like every message disappeared.

--- a/packages/react/src/components.tsx
+++ b/packages/react/src/components.tsx
@@ -10,6 +10,7 @@ import React, {
   useContext,
   useMemo,
   useReducer,
+  useRef,
   isValidElement,
   cloneElement,
   useCallback,
@@ -145,14 +146,22 @@ export function useTranslations<
   const { language, locale } = useLanguage();
   const [, forceRender] = useReducer((s: number) => s + 1, 0);
 
-  const translationsObject = translations.getLoadedMessages(
+  const loadedTranslations = translations.getLoadedMessages(
     language as any,
     locale || language,
   );
+  const lastLoadedTranslations = useRef(loadedTranslations);
+
+  if (loadedTranslations) {
+    lastLoadedTranslations.current = loadedTranslations;
+  }
+
+  const translationsObject =
+    loadedTranslations ?? lastLoadedTranslations.current;
 
   let ready = true;
 
-  if (!translationsObject) {
+  if (!loadedTranslations) {
     if (SERVER_RENDERING) {
       throw new Error(
         `Translations not synchronously available on server render. Applying translations dynamically server-side is not supported.`,

--- a/tests/E2E.test.ts
+++ b/tests/E2E.test.ts
@@ -13,6 +13,8 @@ import {
   previewViteFixture,
 } from '@vocab-private/test-helpers';
 
+import { holdLanguageChunk } from './hold-language-chunk';
+
 describe('E2E', () => {
   describe('Server with initial render', () => {
     let server: TestServer;
@@ -236,6 +238,26 @@ describe('E2E', () => {
       await page.select('#language-select', 'fr');
 
       const message = await page.waitForSelector('#message');
+
+      await expect(message).toMatchTextContent('Bonjour monde');
+    });
+
+    it('should keep the previous language on screen while the next language chunk loads', async () => {
+      const frenchChunk = await holdLanguageChunk(page, 'fr');
+      const message = await page.waitForSelector('#message');
+
+      await page.select('#language-select', 'fr');
+      await frenchChunk.requested;
+      await page.evaluate(
+        () =>
+          new Promise<void>((resolve) => {
+            requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+          }),
+      );
+
+      await expect(message).toMatchTextContent('Hello world');
+
+      frenchChunk.release();
 
       await expect(message).toMatchTextContent('Bonjour monde');
     });

--- a/tests/hold-language-chunk.ts
+++ b/tests/hold-language-chunk.ts
@@ -1,0 +1,43 @@
+import type { HTTPRequest, Page } from 'puppeteer';
+
+/**
+ * Hold every request for a language translations chunk until `release` is
+ * called. `requested` settles when the app first asks for that chunk, which
+ * is how we know a language switch has reached `load()`.
+ */
+export const holdLanguageChunk = async (page: Page, language: string) => {
+  let release = () => {};
+  const released = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  let markRequested = () => {};
+  const requested = new Promise<void>((resolve) => {
+    markRequested = resolve;
+  });
+
+  await page.setRequestInterception(true);
+
+  page.on('request', (request: HTTPRequest) => {
+    const continueRequest = () => {
+      if (!request.isInterceptResolutionHandled()) {
+        return request.continue();
+      }
+    };
+
+    if (request.url().includes(`${language}-translations`)) {
+      markRequested();
+      released.then(continueRequest).catch(() => undefined);
+      return;
+    }
+
+    continueRequest()?.catch(() => undefined);
+  });
+
+  return {
+    requested,
+    release: () => {
+      release();
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- Keep the last loaded messages on screen in `useTranslations` while the next language chunk is in flight
- Add an E2E test that switches language before the new translations resolve

## Why
- Switching language previously rendered a blank string until the chunk loaded, which made every message disappear. This caused a text flash or on slow connections no text while loading

Before:
<img width="640" height="360" alt="language-switch-before" src="https://github.com/user-attachments/assets/7c2bfdcc-4cc7-4126-95bc-2ef862831f2e" />

After:
<img width="640" height="360" alt="language-switch-after" src="https://github.com/user-attachments/assets/550dc1b7-9473-4249-8b03-af71d99b8785" />
